### PR TITLE
Publish v13

### DIFF
--- a/AzureCP.Tests/AugmentationTests.cs
+++ b/AzureCP.Tests/AugmentationTests.cs
@@ -38,7 +38,6 @@ namespace AzureCP.Tests
 
         [TestCase("i:05.t|contoso.local|xyd@FAKE.onmicrosoft.com", false)]
         [TestCase("i:05.t|contoso.local|aadUser1@yvandev.onmicrosoft.com", true)]
-        [TestCase("i:05.t|contoso.local|yvand@outlook.com", true)]
         public void DEBUG_AugmentEntity(string claimValue, bool shouldHavePermissions)
         {
             UnitTestsHelper.TestAugmentationOperation(UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType, claimValue, shouldHavePermissions);

--- a/AzureCP.Tests/AugmentationTests.cs
+++ b/AzureCP.Tests/AugmentationTests.cs
@@ -1,0 +1,23 @@
+﻿using NUnit.Framework;
+
+namespace AzureCP.Tests
+{
+    [TestFixture]
+    [Parallelizable(ParallelScope.Children)]
+    public class AugmentationTests
+    {
+        [Test, TestCaseSource(typeof(ValidateEntityDataSource), "GetTestData")]
+        [MaxTime(UnitTestsHelper.MaxTime)]
+        [Repeat(UnitTestsHelper.TestRepeatCount)]
+        public void AugmentEntity(ValidateEntityData registrationData)
+        {
+            UnitTestsHelper.DoAugmentationOperationAndVerifyResult(UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType, registrationData.ClaimValue, registrationData.IsMemberOfTrustedGroup);
+        }
+
+        [TestCase("i:05.t|contoso.local|xyd@FAKE.onmicrosoft.com", false)]
+        public void DEBUG_AugmentEntity(string claimValue, bool shouldHavePermissions)
+        {
+            UnitTestsHelper.DoAugmentationOperationAndVerifyResult(UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType, claimValue, shouldHavePermissions);
+        }
+    }
+}

--- a/AzureCP.Tests/AugmentationTests.cs
+++ b/AzureCP.Tests/AugmentationTests.cs
@@ -33,13 +33,13 @@ namespace AzureCP.Tests
         [MaxTime(UnitTestsHelper.MaxTime)]
         public void AugmentEntity(ValidateEntityData registrationData)
         {
-            UnitTestsHelper.DoAugmentationOperationAndVerifyResult(UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType, registrationData.ClaimValue, registrationData.IsMemberOfTrustedGroup);
+            UnitTestsHelper.TestAugmentationOperation(UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType, registrationData.ClaimValue, registrationData.IsMemberOfTrustedGroup);
         }
 
         [TestCase("i:05.t|contoso.local|xyd@FAKE.onmicrosoft.com", false)]
         public void DEBUG_AugmentEntity(string claimValue, bool shouldHavePermissions)
         {
-            UnitTestsHelper.DoAugmentationOperationAndVerifyResult(UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType, claimValue, shouldHavePermissions);
+            UnitTestsHelper.TestAugmentationOperation(UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType, claimValue, shouldHavePermissions);
         }
     }
 }

--- a/AzureCP.Tests/AugmentationTests.cs
+++ b/AzureCP.Tests/AugmentationTests.cs
@@ -30,7 +30,7 @@ namespace AzureCP.Tests
         }
 
         [Test, TestCaseSource(typeof(ValidateEntityDataSource), "GetTestData")]
-        [MaxTime(UnitTestsHelper.MaxTime)]
+        [Repeat(UnitTestsHelper.TestRepeatCount)]
         public void AugmentEntity(ValidateEntityData registrationData)
         {
             UnitTestsHelper.TestAugmentationOperation(UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType, registrationData.ClaimValue, registrationData.IsMemberOfTrustedGroup);

--- a/AzureCP.Tests/AugmentationTests.cs
+++ b/AzureCP.Tests/AugmentationTests.cs
@@ -1,4 +1,6 @@
-﻿using NUnit.Framework;
+﻿using azurecp;
+using NUnit.Framework;
+using System;
 
 namespace AzureCP.Tests
 {
@@ -6,9 +8,29 @@ namespace AzureCP.Tests
     [Parallelizable(ParallelScope.Children)]
     public class AugmentationTests
     {
+        private AzureCPConfig Config;
+        private AzureCPConfig BackupConfig;
+
+        [OneTimeSetUp]
+        public void Init()
+        {
+            Console.WriteLine($"Starting augmentation test {TestContext.CurrentContext.Test.Name}...");
+            Config = AzureCPConfig.GetConfiguration(UnitTestsHelper.ClaimsProviderConfigName);
+            BackupConfig = Config.CopyPersistedProperties();
+            Config.EnableAugmentation = true;
+            Config.Update();
+        }
+
+        [OneTimeTearDown]
+        public void Cleanup()
+        {
+            Config.ApplyConfiguration(BackupConfig);
+            Config.Update();
+            Console.WriteLine($"Restored actual configuration.");
+        }
+
         [Test, TestCaseSource(typeof(ValidateEntityDataSource), "GetTestData")]
         [MaxTime(UnitTestsHelper.MaxTime)]
-        [Repeat(UnitTestsHelper.TestRepeatCount)]
         public void AugmentEntity(ValidateEntityData registrationData)
         {
             UnitTestsHelper.DoAugmentationOperationAndVerifyResult(UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType, registrationData.ClaimValue, registrationData.IsMemberOfTrustedGroup);

--- a/AzureCP.Tests/AugmentationTests.cs
+++ b/AzureCP.Tests/AugmentationTests.cs
@@ -37,6 +37,8 @@ namespace AzureCP.Tests
         }
 
         [TestCase("i:05.t|contoso.local|xyd@FAKE.onmicrosoft.com", false)]
+        [TestCase("i:05.t|contoso.local|aadUser1@yvandev.onmicrosoft.com", true)]
+        [TestCase("i:05.t|contoso.local|yvand@outlook.com", true)]
         public void DEBUG_AugmentEntity(string claimValue, bool shouldHavePermissions)
         {
             UnitTestsHelper.TestAugmentationOperation(UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType, claimValue, shouldHavePermissions);

--- a/AzureCP.Tests/AugmentationTests.cs
+++ b/AzureCP.Tests/AugmentationTests.cs
@@ -15,7 +15,7 @@ namespace AzureCP.Tests
         public void Init()
         {
             Console.WriteLine($"Starting augmentation test {TestContext.CurrentContext.Test.Name}...");
-            Config = AzureCPConfig.GetConfiguration(UnitTestsHelper.ClaimsProviderConfigName);
+            Config = AzureCPConfig.GetConfiguration(UnitTestsHelper.ClaimsProviderConfigName, UnitTestsHelper.SPTrust.Name);
             BackupConfig = Config.CopyPersistedProperties();
             Config.EnableAugmentation = true;
             Config.Update();

--- a/AzureCP.Tests/AzureCP.Tests.csproj
+++ b/AzureCP.Tests/AzureCP.Tests.csproj
@@ -1,0 +1,84 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props')" />
+  <Import Project="..\packages\NUnit.3.10.1\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.10.1\build\NUnit.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{DB8C79E5-F7F7-4841-8A8C-A9832A9CAE88}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>AzureCP.Tests</RootNamespace>
+    <AssemblyName>AzureCP.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="CsvReader, Version=0.9.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\CsvTools.1.0.12\lib\CsvReader.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.SharePoint, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>C:\Program Files\Common Files\microsoft shared\Web Server Extensions\15\ISAPI\Microsoft.SharePoint.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework, Version=3.10.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.10.1\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AugmentationTests.cs" />
+    <Compile Include="UnitTestsHelper.cs" />
+    <Compile Include="CustomConfigTests.cs" />
+    <Compile Include="ModifyConfigTests.cs" />
+    <Compile Include="PeoplePickerTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\AzureCP\AzureCP.csproj">
+      <Project>{eec47949-34b5-4805-a04d-a372be75d3cb}</Project>
+      <Name>AzureCP</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit.3.10.1\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.10.1\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props'))" />
+  </Target>
+</Project>

--- a/AzureCP.Tests/CustomConfigTests.cs
+++ b/AzureCP.Tests/CustomConfigTests.cs
@@ -68,5 +68,24 @@ namespace AzureCP.Tests
                 Config.Update();
             }
         }
+
+        [Test, TestCaseSource(typeof(ValidateEntityDataSource), "GetTestData")]
+        //[Repeat(UnitTestsHelper.TestRepeatCount)]
+        public void RequireExactMatchDuringSearch(ValidateEntityData registrationData)
+        {
+            Config.FilterExactMatchOnly = true;
+            Config.Update();
+
+            try
+            {
+                int expectedCount = registrationData.ShouldValidate ? 1 : 0;
+                UnitTestsHelper.TestSearchOperation(registrationData.ClaimValue, expectedCount, registrationData.ClaimValue);
+            }
+            finally
+            {
+                Config.FilterExactMatchOnly = false;
+                Config.Update();
+            }
+        }
     }
 }

--- a/AzureCP.Tests/CustomConfigTests.cs
+++ b/AzureCP.Tests/CustomConfigTests.cs
@@ -40,14 +40,12 @@ namespace AzureCP.Tests
             ctConfig.PrefixToBypassLookup = "ext:";
             Config.Update();
 
-            SPProviderHierarchyTree[] providerResults = UnitTestsHelper.DoSearchOperation(inputValue);
-            UnitTestsHelper.VerifySearchResult(providerResults, expectedCount, expectedClaimValue);
+            UnitTestsHelper.TestSearchOperation(inputValue, expectedCount, expectedClaimValue);
 
             if (expectedCount > 0)
             {
                 SPClaim inputClaim = new SPClaim(UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType, expectedClaimValue, ClaimValueTypes.String, SPOriginalIssuers.Format(SPOriginalIssuerType.TrustedProvider, UnitTestsHelper.SPTrust.Name));
-                PickerEntity[] entities = UnitTestsHelper.DoValidationOperation(inputClaim);
-                UnitTestsHelper.VerifyValidationResult(entities, true, expectedClaimValue);
+                UnitTestsHelper.TestValidationOperation(inputClaim, true, expectedClaimValue);
             }
         }
 
@@ -57,12 +55,10 @@ namespace AzureCP.Tests
             Config.AlwaysResolveUserInput = true;
             Config.Update();
 
-            SPProviderHierarchyTree[] providerResults = UnitTestsHelper.DoSearchOperation(UnitTestsHelper.RandomClaimValue);
-            UnitTestsHelper.VerifySearchResult(providerResults, 2, UnitTestsHelper.RandomClaimValue);
+            UnitTestsHelper.TestSearchOperation(UnitTestsHelper.RandomClaimValue, 2, UnitTestsHelper.RandomClaimValue);
 
             SPClaim inputClaim = new SPClaim(UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType, UnitTestsHelper.RandomClaimValue, ClaimValueTypes.String, SPOriginalIssuers.Format(SPOriginalIssuerType.TrustedProvider, UnitTestsHelper.SPTrust.Name));
-            PickerEntity[] entities = UnitTestsHelper.DoValidationOperation(inputClaim);
-            UnitTestsHelper.VerifyValidationResult(entities, true, UnitTestsHelper.RandomClaimValue);
+            UnitTestsHelper.TestValidationOperation(inputClaim, true, UnitTestsHelper.RandomClaimValue);
 
             Config.AlwaysResolveUserInput = false;
             Config.Update();

--- a/AzureCP.Tests/CustomConfigTests.cs
+++ b/AzureCP.Tests/CustomConfigTests.cs
@@ -55,13 +55,18 @@ namespace AzureCP.Tests
             Config.AlwaysResolveUserInput = true;
             Config.Update();
 
-            UnitTestsHelper.TestSearchOperation(UnitTestsHelper.RandomClaimValue, 2, UnitTestsHelper.RandomClaimValue);
+            try
+            {
+                UnitTestsHelper.TestSearchOperation(UnitTestsHelper.RandomClaimValue, 2, UnitTestsHelper.RandomClaimValue);
 
-            SPClaim inputClaim = new SPClaim(UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType, UnitTestsHelper.RandomClaimValue, ClaimValueTypes.String, SPOriginalIssuers.Format(SPOriginalIssuerType.TrustedProvider, UnitTestsHelper.SPTrust.Name));
-            UnitTestsHelper.TestValidationOperation(inputClaim, true, UnitTestsHelper.RandomClaimValue);
-
-            Config.AlwaysResolveUserInput = false;
-            Config.Update();
+                SPClaim inputClaim = new SPClaim(UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType, UnitTestsHelper.RandomClaimValue, ClaimValueTypes.String, SPOriginalIssuers.Format(SPOriginalIssuerType.TrustedProvider, UnitTestsHelper.SPTrust.Name));
+                UnitTestsHelper.TestValidationOperation(inputClaim, true, UnitTestsHelper.RandomClaimValue);
+            }
+            finally
+            {
+                Config.AlwaysResolveUserInput = false;
+                Config.Update();
+            }
         }
     }
 }

--- a/AzureCP.Tests/CustomConfigTests.cs
+++ b/AzureCP.Tests/CustomConfigTests.cs
@@ -19,7 +19,7 @@ namespace AzureCP.Tests
         public void Init()
         {
             Console.WriteLine($"Starting custom config test {TestContext.CurrentContext.Test.Name}...");
-            Config = AzureCPConfig.GetConfiguration(UnitTestsHelper.ClaimsProviderConfigName);
+            Config = AzureCPConfig.GetConfiguration(UnitTestsHelper.ClaimsProviderConfigName, UnitTestsHelper.SPTrust.Name);
             BackupConfig = Config.CopyPersistedProperties();
             Config.ResetClaimTypesList();
         }

--- a/AzureCP.Tests/CustomConfigTests.cs
+++ b/AzureCP.Tests/CustomConfigTests.cs
@@ -1,0 +1,74 @@
+﻿using azurecp;
+using Microsoft.SharePoint.Administration.Claims;
+using Microsoft.SharePoint.WebControls;
+using NUnit.Framework;
+using System;
+using System.Linq;
+using System.Security.Claims;
+
+namespace AzureCP.Tests
+{
+    [TestFixture]
+    public class CustomConfigTests
+    {
+        public const string ClaimsProviderConfigName = "AzureCPConfig";
+        public const string NonExistingClaimType = "http://schemas.yvand.com/ws/claims/random";
+        public static string GroupsClaimType = ClaimsProviderConstants.DefaultMainGroupClaimType;
+
+        private AzureCPConfig Config;
+        private AzureCPConfig BackupConfig;
+
+        [OneTimeSetUp]
+        public void Init()
+        {
+            Console.WriteLine($"Starting custom config test {TestContext.CurrentContext.Test.Name}...");
+            Config = AzureCPConfig.GetConfiguration(ClaimsProviderConfigName);
+            BackupConfig = Config.CopyPersistedProperties();
+            Config.ResetClaimTypesList();
+        }
+
+        [OneTimeTearDown]
+        public void Cleanup()
+        {
+            Config.ApplyConfiguration(BackupConfig);
+            Config.Update();
+            Console.WriteLine($"Restored actual configuration.");
+        }
+
+        [TestCase("ext:externalUser@contoso.com", 1, "externalUser@contoso.com")]
+        [TestCase("ext:", 0, "")]
+        public void TestPrefixToBypassLookup(string inputValue, int expectedCount, string expectedClaimValue)
+        {
+            ClaimTypeConfig ctConfig = Config.ClaimTypes.FirstOrDefault(x => String.Equals(UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType, x.ClaimType, StringComparison.InvariantCultureIgnoreCase));
+            ctConfig.PrefixToBypassLookup = "ext:";
+            Config.Update();
+
+            SPProviderHierarchyTree[] providerResults = UnitTestsHelper.DoSearchOperation(inputValue);
+            UnitTestsHelper.VerifySearchResult(providerResults, expectedCount, expectedClaimValue);
+
+            if (expectedCount > 0)
+            {
+                SPClaim inputClaim = new SPClaim(UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType, expectedClaimValue, ClaimValueTypes.String, SPOriginalIssuers.Format(SPOriginalIssuerType.TrustedProvider, UnitTestsHelper.SPTrust.Name));
+                PickerEntity[] entities = UnitTestsHelper.DoValidationOperation(inputClaim);
+                UnitTestsHelper.VerifyValidationResult(entities, true, expectedClaimValue);
+            }
+        }
+
+        [Test]
+        public void BypassServer()
+        {
+            Config.AlwaysResolveUserInput = true;
+            Config.Update();
+
+            SPProviderHierarchyTree[] providerResults = UnitTestsHelper.DoSearchOperation(UnitTestsHelper.NonExistentClaimValue);
+            UnitTestsHelper.VerifySearchResult(providerResults, 2, UnitTestsHelper.NonExistentClaimValue);
+
+            SPClaim inputClaim = new SPClaim(UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType, UnitTestsHelper.NonExistentClaimValue, ClaimValueTypes.String, SPOriginalIssuers.Format(SPOriginalIssuerType.TrustedProvider, UnitTestsHelper.SPTrust.Name));
+            PickerEntity[] entities = UnitTestsHelper.DoValidationOperation(inputClaim);
+            UnitTestsHelper.VerifyValidationResult(entities, true, UnitTestsHelper.NonExistentClaimValue);
+
+            Config.AlwaysResolveUserInput = false;
+            Config.Update();
+        }
+    }
+}

--- a/AzureCP.Tests/CustomConfigTests.cs
+++ b/AzureCP.Tests/CustomConfigTests.cs
@@ -11,10 +11,7 @@ namespace AzureCP.Tests
     [TestFixture]
     public class CustomConfigTests
     {
-        public const string ClaimsProviderConfigName = "AzureCPConfig";
-        public const string NonExistingClaimType = "http://schemas.yvand.com/ws/claims/random";
         public static string GroupsClaimType = ClaimsProviderConstants.DefaultMainGroupClaimType;
-
         private AzureCPConfig Config;
         private AzureCPConfig BackupConfig;
 
@@ -22,7 +19,7 @@ namespace AzureCP.Tests
         public void Init()
         {
             Console.WriteLine($"Starting custom config test {TestContext.CurrentContext.Test.Name}...");
-            Config = AzureCPConfig.GetConfiguration(ClaimsProviderConfigName);
+            Config = AzureCPConfig.GetConfiguration(UnitTestsHelper.ClaimsProviderConfigName);
             BackupConfig = Config.CopyPersistedProperties();
             Config.ResetClaimTypesList();
         }
@@ -60,12 +57,12 @@ namespace AzureCP.Tests
             Config.AlwaysResolveUserInput = true;
             Config.Update();
 
-            SPProviderHierarchyTree[] providerResults = UnitTestsHelper.DoSearchOperation(UnitTestsHelper.NonExistentClaimValue);
-            UnitTestsHelper.VerifySearchResult(providerResults, 2, UnitTestsHelper.NonExistentClaimValue);
+            SPProviderHierarchyTree[] providerResults = UnitTestsHelper.DoSearchOperation(UnitTestsHelper.RandomClaimValue);
+            UnitTestsHelper.VerifySearchResult(providerResults, 2, UnitTestsHelper.RandomClaimValue);
 
-            SPClaim inputClaim = new SPClaim(UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType, UnitTestsHelper.NonExistentClaimValue, ClaimValueTypes.String, SPOriginalIssuers.Format(SPOriginalIssuerType.TrustedProvider, UnitTestsHelper.SPTrust.Name));
+            SPClaim inputClaim = new SPClaim(UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType, UnitTestsHelper.RandomClaimValue, ClaimValueTypes.String, SPOriginalIssuers.Format(SPOriginalIssuerType.TrustedProvider, UnitTestsHelper.SPTrust.Name));
             PickerEntity[] entities = UnitTestsHelper.DoValidationOperation(inputClaim);
-            UnitTestsHelper.VerifyValidationResult(entities, true, UnitTestsHelper.NonExistentClaimValue);
+            UnitTestsHelper.VerifyValidationResult(entities, true, UnitTestsHelper.RandomClaimValue);
 
             Config.AlwaysResolveUserInput = false;
             Config.Update();

--- a/AzureCP.Tests/ModifyConfigTests.cs
+++ b/AzureCP.Tests/ModifyConfigTests.cs
@@ -9,6 +9,7 @@ namespace AzureCP.Tests
     public class ModifyConfigTests
     {
         private AzureCPConfig Config;
+        const string ConfigUpdateErrorMessage = "Some changes made to list ClaimTypes are invalid and cannot be committed to configuration database. Inspect inner exception for more details about the error.";
 
         [OneTimeSetUp]
         public void Init()
@@ -28,55 +29,55 @@ namespace AzureCP.Tests
             // Adding a ClaimTypeConfig with a claim type already set should fail
             ctConfig.ClaimType = UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType;
             ctConfig.DirectoryObjectProperty = UnitTestsHelper.RandomObjectProperty;
-            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig));
+            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig), $"Adding a ClaimTypeConfig with a claim type already set should throw exception InvalidOperationException with this message: \"Claim type '{UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType}' already exists in the collection\"");
 
             // Adding a ClaimTypeConfig with UseMainClaimTypeOfDirectoryObject = false (default value) and DirectoryObjectProperty not set should fail
             ctConfig.ClaimType = UnitTestsHelper.RandomClaimType;
             ctConfig.DirectoryObjectProperty = AzureADObjectProperty.NotSet;
-            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig));
+            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig), $"Adding a ClaimTypeConfig with a claim type already set should throw exception InvalidOperationException with this message: \"Property DirectoryObjectProperty is required\"");
 
             // Adding a ClaimTypeConfig with UseMainClaimTypeOfDirectoryObject = true and ClaimType set should fail
             ctConfig.ClaimType = UnitTestsHelper.RandomClaimType;
             ctConfig.DirectoryObjectProperty = UnitTestsHelper.RandomObjectProperty;
             ctConfig.UseMainClaimTypeOfDirectoryObject = true;
-            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig));
+            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig), $"Adding a ClaimTypeConfig with a claim type already set should throw exception InvalidOperationException with this message: \"No claim type should be set if UseMainClaimTypeOfDirectoryObject is set to true\"");
 
             // Adding a ClaimTypeConfig with EntityType 'Group' should fail since 1 already exists by default and AzureCP allows only 1 claim type for EntityType 'Group'
             ctConfig.ClaimType = UnitTestsHelper.RandomClaimType;
             ctConfig.DirectoryObjectProperty = UnitTestsHelper.RandomObjectProperty;
             ctConfig.EntityType = DirectoryObjectType.Group;
             ctConfig.UseMainClaimTypeOfDirectoryObject = false;
-            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig));
+            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig), $"Adding a ClaimTypeConfig with a claim type already set should throw exception InvalidOperationException with this message: \"A claim type for EntityType 'Group' already exists in the collection\"");
 
             // Adding a valid ClaimTypeConfig should succeed
             ctConfig.ClaimType = UnitTestsHelper.RandomClaimType;
             ctConfig.DirectoryObjectProperty = UnitTestsHelper.RandomObjectProperty;
             ctConfig.EntityType = DirectoryObjectType.User;
             ctConfig.UseMainClaimTypeOfDirectoryObject = false;
-            Assert.DoesNotThrow(() => Config.ClaimTypes.Add(ctConfig));
+            Assert.DoesNotThrow(() => Config.ClaimTypes.Add(ctConfig), $"ClaimTypeConfig {UnitTestsHelper.RandomClaimType} should have been added successfully but was not");
 
             // Adding a ClaimTypeConfig twice should fail
-            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig));
+            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig), $"Adding a ClaimTypeConfig with a claim type already set should throw exception InvalidOperationException with this message: \"Claim type '{UnitTestsHelper.RandomClaimType}' already exists in the collection\"");
 
             // Deleting the ClaimTypeConfig should succeed
-            Assert.IsTrue(Config.ClaimTypes.Remove(ctConfig));
+            Assert.IsTrue(Config.ClaimTypes.Remove(ctConfig), $"ClaimTypeConfig {UnitTestsHelper.RandomClaimType} should have been removed successfully but was not");
         }
 
         [Test]
         public void ModifyOrDeleteIdentityClaimTypeConfig()
         {
-            // Deleting identity claim type from its claim type should fail
+            // Deleting identity claim type from ClaimTypes list based on its claim type should fail
             string identityClaimType = UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType;
-            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Remove(identityClaimType));
+            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Remove(identityClaimType), $"Deleting identity claim type from ClaimTypes list should throw exception InvalidOperationException with this message: \"Cannot delete claim type \"{UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType}\" because it is the identity claim type of \"{UnitTestsHelper.SPTrust.Name}\"\"");
 
-            // Deleting identity claim type from its ClaimTypeConfig should fail
+            // Deleting identity claim type from ClaimTypes list based on its ClaimTypeConfig should fail
             ClaimTypeConfig identityCTConfig = Config.ClaimTypes.FirstOrDefault(x => String.Equals(UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType, x.ClaimType, StringComparison.InvariantCultureIgnoreCase));
             Assert.IsNotNull(identityCTConfig);
-            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Remove(identityCTConfig));
+            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Remove(identityClaimType), $"Deleting identity claim type from ClaimTypes list should throw exception InvalidOperationException with this message: \"Cannot delete claim type \"{UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType}\" because it is the identity claim type of \"{UnitTestsHelper.SPTrust.Name}\"\"");
 
             // Modify identity ClaimTypeConfig to set its EntityType to Group should fail
             identityCTConfig.EntityType = DirectoryObjectType.Group;
-            Assert.Throws<InvalidOperationException>(() => Config.Update());
+            Assert.Throws<InvalidOperationException>(() => Config.Update(), $"Modifying identity claim type to set its EntityType to Group should throw exception InvalidOperationException with this message: \"{ConfigUpdateErrorMessage}\"");
         }
 
         [Test]
@@ -86,12 +87,12 @@ namespace AzureCP.Tests
 
             // Setting a duplicate claim type on a new item should fail
             ClaimTypeConfig ctConfig = new ClaimTypeConfig() { ClaimType = firstCTConfig.ClaimType, DirectoryObjectProperty = AzureADObjectProperty.OfficeLocation };
-            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig));
+            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig), $"Adding a ClaimTypeConfig with property ClaimType already defined in another ClaimTypeConfig should throw exception InvalidOperationException with this message: \"Claim type '{firstCTConfig.ClaimType}' already exists in the collection\"");
 
             // Setting a duplicate claim type on items already existing in the list should fail
-            var anotherCTConfig = Config.ClaimTypes.FirstOrDefault(x => !String.IsNullOrEmpty(x.ClaimType) && !String.Equals(firstCTConfig.ClaimType, x.ClaimType, StringComparison.InvariantCultureIgnoreCase));
+            ClaimTypeConfig anotherCTConfig = Config.ClaimTypes.FirstOrDefault(x => !String.IsNullOrEmpty(x.ClaimType) && !String.Equals(firstCTConfig.ClaimType, x.ClaimType, StringComparison.InvariantCultureIgnoreCase));
             anotherCTConfig.ClaimType = firstCTConfig.ClaimType;
-            Assert.Throws<InvalidOperationException>(() => Config.Update());
+            Assert.Throws<InvalidOperationException>(() => Config.Update(), $"Modifying an existing claim type to set a claim type already defined should throw exception InvalidOperationException with this message: \"{ConfigUpdateErrorMessage}\"");
         }
 
         [Test]
@@ -101,13 +102,13 @@ namespace AzureCP.Tests
 
             // Setting a duplicate PrefixToBypassLookup on 2 items already existing in the list should fail
             Config.ClaimTypes.Where(x => !String.IsNullOrEmpty(x.ClaimType)).Take(2).Select(x => x.PrefixToBypassLookup = prefixToBypassLookup).ToList();
-            Assert.Throws<InvalidOperationException>(() => Config.Update());
+            Assert.Throws<InvalidOperationException>(() => Config.Update(), $"Setting a duplicate PrefixToBypassLookup on 2 items already existing in the list should throw exception InvalidOperationException with this message: \"{ConfigUpdateErrorMessage}\"");
 
             // Setting a PrefixToBypassLookup on an existing item and add a new item with the same PrefixToBypassLookup should fail
             var firstCTConfig = Config.ClaimTypes.FirstOrDefault(x => !String.IsNullOrEmpty(x.ClaimType));
             firstCTConfig.PrefixToBypassLookup = prefixToBypassLookup;
             ClaimTypeConfig ctConfig = new ClaimTypeConfig() { ClaimType = UnitTestsHelper.RandomClaimType, PrefixToBypassLookup = prefixToBypassLookup, DirectoryObjectProperty = AzureADObjectProperty.OfficeLocation };
-            Assert.Throws<InvalidOperationException>(() => Config.Update());
+            Assert.Throws<InvalidOperationException>(() => Config.Update(), $"Setting a duplicate PrefixToBypassLookup on an existing item and add a new item with the same PrefixToBypassLookup should throw exception InvalidOperationException with this message: \"{ConfigUpdateErrorMessage}\"");
         }
 
         [Test]
@@ -116,14 +117,14 @@ namespace AzureCP.Tests
             string entityDataKey = "test";
 
             // Setting a duplicate EntityDataKey on 2 items already existing in the list should fail
-            Config.ClaimTypes.Where(x => !String.IsNullOrEmpty(x.ClaimType)).Take(2).Select(x => x.EntityDataKey = entityDataKey).ToList();
-            Assert.Throws<InvalidOperationException>(() => Config.Update());
+            Config.ClaimTypes.Where(x => x.EntityType == DirectoryObjectType.User).Take(2).Select(x => x.EntityDataKey = entityDataKey).ToList();
+            Assert.Throws<InvalidOperationException>(() => Config.Update(), $"Setting a duplicate EntityDataKey on 2 items already existing in the list should throw exception InvalidOperationException with this message: \"{ConfigUpdateErrorMessage}\"");
 
             // Setting a EntityDataKey on an existing item and add a new item with the same EntityDataKey should fail
             var firstCTConfig = Config.ClaimTypes.FirstOrDefault(x => !String.IsNullOrEmpty(x.ClaimType));
             firstCTConfig.EntityDataKey = entityDataKey;
             ClaimTypeConfig ctConfig = new ClaimTypeConfig() { ClaimType = UnitTestsHelper.RandomClaimType, EntityDataKey = entityDataKey, DirectoryObjectProperty = UnitTestsHelper.RandomObjectProperty };
-            Assert.Throws<InvalidOperationException>(() => Config.Update());
+            Assert.Throws<InvalidOperationException>(() => Config.Update(), $"Setting a EntityDataKey on an existing item and add a new item with the same EntityDataKey should throw exception InvalidOperationException with this message: \"{ConfigUpdateErrorMessage}\"");
         }
 
         [Test]

--- a/AzureCP.Tests/ModifyConfigTests.cs
+++ b/AzureCP.Tests/ModifyConfigTests.cs
@@ -146,5 +146,36 @@ namespace AzureCP.Tests
             // Delete the ClaimTypeConfig should succeed
             Assert.IsTrue(Config.ClaimTypes.Remove(ctConfig), "Delete the ClaimTypeConfig should succeed");
         }
+
+        [Test]
+        public void ModifyUserIdentifier()
+        {
+            IdentityClaimTypeConfig backupIdentityCTConfig = Config.ClaimTypes.FirstOrDefault(x => x is IdentityClaimTypeConfig) as IdentityClaimTypeConfig;
+            backupIdentityCTConfig = backupIdentityCTConfig.CopyPersistedProperties() as IdentityClaimTypeConfig;
+
+            // Member UserType
+            Assert.Throws<ArgumentNullException>(() => Config.ClaimTypes.UpdateUserIdentifier(AzureADObjectProperty.NotSet), $"Update user identifier with value NotSet should throw exception ArgumentNullException");
+
+            bool configUpdated = Config.ClaimTypes.UpdateUserIdentifier(UnitTestsHelper.RandomObjectProperty);
+            Assert.IsTrue(configUpdated, $"Update user identifier with any AzureADObjectProperty should succeed and return true");
+
+            configUpdated = Config.ClaimTypes.UpdateUserIdentifier(backupIdentityCTConfig.DirectoryObjectProperty);
+            Assert.IsTrue(configUpdated, $"Update user identifier with any AzureADObjectProperty should succeed and return true");
+
+            configUpdated = Config.ClaimTypes.UpdateUserIdentifier(backupIdentityCTConfig.DirectoryObjectProperty);
+            Assert.IsFalse(configUpdated, $"Update user identifier with the same AzureADObjectProperty should not change anything and return false");
+
+            // Gest UserType
+            Assert.Throws<ArgumentNullException>(() => Config.ClaimTypes.UpdateIdentifierForGuestUsers(AzureADObjectProperty.NotSet), $"Update user identifier of Guest UserType with value NotSet should throw exception ArgumentNullException");
+
+            configUpdated = Config.ClaimTypes.UpdateIdentifierForGuestUsers(UnitTestsHelper.RandomObjectProperty);
+            Assert.IsTrue(configUpdated, $"Update user identifier of Guest UserType with any AzureADObjectProperty should succeed and return true");
+
+            configUpdated = Config.ClaimTypes.UpdateIdentifierForGuestUsers(backupIdentityCTConfig.DirectoryObjectPropertyForGuestUsers);
+            Assert.IsTrue(configUpdated, $"Update user identifier of Guest UserType with any AzureADObjectProperty should succeed and return true");
+
+            configUpdated = Config.ClaimTypes.UpdateIdentifierForGuestUsers(backupIdentityCTConfig.DirectoryObjectPropertyForGuestUsers);
+            Assert.IsFalse(configUpdated, $"Update user identifier of Guest UserType with the same AzureADObjectProperty should not change anything and return false");
+        }
     }
 }

--- a/AzureCP.Tests/ModifyConfigTests.cs
+++ b/AzureCP.Tests/ModifyConfigTests.cs
@@ -165,7 +165,7 @@ namespace AzureCP.Tests
             configUpdated = Config.ClaimTypes.UpdateUserIdentifier(backupIdentityCTConfig.DirectoryObjectProperty);
             Assert.IsFalse(configUpdated, $"Update user identifier with the same AzureADObjectProperty should not change anything and return false");
 
-            // Gest UserType
+            // Guest UserType
             Assert.Throws<ArgumentNullException>(() => Config.ClaimTypes.UpdateIdentifierForGuestUsers(AzureADObjectProperty.NotSet), $"Update user identifier of Guest UserType with value NotSet should throw exception ArgumentNullException");
 
             configUpdated = Config.ClaimTypes.UpdateIdentifierForGuestUsers(UnitTestsHelper.RandomObjectProperty);

--- a/AzureCP.Tests/ModifyConfigTests.cs
+++ b/AzureCP.Tests/ModifyConfigTests.cs
@@ -1,0 +1,114 @@
+﻿using azurecp;
+using NUnit.Framework;
+using System;
+using System.Linq;
+
+namespace AzureCP.Tests
+{
+    [TestFixture]
+    public class ModifyConfigTests
+    {
+        public const string ClaimsProviderConfigName = "AzureCPConfig";
+        public const string NonExistingClaimType = "http://schemas.yvand.com/ws/claims/random";
+
+        private AzureCPConfig Config;
+
+        [OneTimeSetUp]
+        public void Init()
+        {
+            AzureCPConfig configFromConfigDB = AzureCPConfig.GetConfiguration(ClaimsProviderConfigName);
+            // Create a local copy, otherwise changes will impact the whole process (even without calling Update method)
+            Config = configFromConfigDB.CopyPersistedProperties();
+            // Reset configuration to test its default for the tests
+            Config.ResetCurrentConfiguration();
+        }
+
+        [Test]
+        public void AddClaimTypeConfig()
+        {
+            ClaimTypeConfig ctConfig = new ClaimTypeConfig();
+
+            // Identity claim type already exists and a claim type cannot be added twice
+            ctConfig.ClaimType = UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType;
+            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig));
+
+            // Property DirectoryObjectProperty should be set
+            ctConfig.ClaimType = NonExistingClaimType;
+            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig));
+
+            // Property ClaimType should be empty if UseMainClaimTypeOfDirectoryObject is true
+            ctConfig.UseMainClaimTypeOfDirectoryObject = true;
+            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig));
+
+            // AzureCP allows only 1 claim type for EntityType 'Group'
+            ctConfig.EntityType = DirectoryObjectType.Group;
+            ctConfig.UseMainClaimTypeOfDirectoryObject = false;
+            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig));
+
+            // Valid ClaimTypeConfig
+            ctConfig.UseMainClaimTypeOfDirectoryObject = false;
+            ctConfig.EntityType = DirectoryObjectType.User;
+            ctConfig.DirectoryObjectProperty = AzureADObjectProperty.UserPrincipalName;
+            Config.ClaimTypes.Add(ctConfig);
+        }
+
+        [Test]
+        public void DeleteIdentityClaimTypeConfig()
+        {
+            string identityClaimType = UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType;
+            Assert.IsNotEmpty(identityClaimType);
+            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Remove(identityClaimType));
+
+            ClaimTypeConfig identityCTConfig = Config.ClaimTypes.FirstOrDefault(x => String.Equals(UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType, x.ClaimType, StringComparison.InvariantCultureIgnoreCase));
+            Assert.IsNotNull(identityCTConfig);
+            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Remove(identityCTConfig));
+        }
+
+        [Test]
+        public void DuplicateClaimType()
+        {
+            var firstCTConfig = Config.ClaimTypes.FirstOrDefault(x => !String.IsNullOrEmpty(x.ClaimType));
+
+            // Set a duplicate claim type on a new item
+            ClaimTypeConfig ctConfig = new ClaimTypeConfig() { ClaimType = firstCTConfig.ClaimType, DirectoryObjectProperty = AzureADObjectProperty.OfficeLocation };
+            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig));
+
+            // Set a duplicate claim type on items already existing in the list
+            var anotherCTConfig = Config.ClaimTypes.FirstOrDefault(x => !String.IsNullOrEmpty(x.ClaimType) && !String.Equals(firstCTConfig.ClaimType, x.ClaimType, StringComparison.InvariantCultureIgnoreCase));
+            anotherCTConfig.ClaimType = firstCTConfig.ClaimType;
+            Assert.Throws<InvalidOperationException>(() => Config.Update());
+        }
+
+        [Test]
+        public void DuplicatePrefixToBypassLookup()
+        {
+            string prefixToBypassLookup = "test:";
+
+            // Set a duplicate PrefixToBypassLookup on 2 items already existing in the list
+            Config.ClaimTypes.Where(x => !String.IsNullOrEmpty(x.ClaimType)).Take(2).Select(x => x.PrefixToBypassLookup = prefixToBypassLookup).ToList();
+            Assert.Throws<InvalidOperationException>(() => Config.Update());
+
+            // Set a PrefixToBypassLookup on an existing item and add a new item with the same PrefixToBypassLookup
+            var firstCTConfig = Config.ClaimTypes.FirstOrDefault(x => !String.IsNullOrEmpty(x.ClaimType));
+            firstCTConfig.PrefixToBypassLookup = prefixToBypassLookup;
+            ClaimTypeConfig ctConfig = new ClaimTypeConfig() { ClaimType = NonExistingClaimType, PrefixToBypassLookup = prefixToBypassLookup, DirectoryObjectProperty = AzureADObjectProperty.OfficeLocation };
+            Assert.Throws<InvalidOperationException>(() => Config.Update());
+        }
+
+        [Test]
+        public void DuplicateEntityDataKey()
+        {
+            string entityDataKey = "test";
+
+            // Set a duplicate EntityDataKey on 2 items already existing in the list
+            Config.ClaimTypes.Where(x => !String.IsNullOrEmpty(x.ClaimType)).Take(2).Select(x => x.EntityDataKey = entityDataKey).ToList();
+            Assert.Throws<InvalidOperationException>(() => Config.Update());
+
+            // Set a EntityDataKey on an existing item and add a new item with the same EntityDataKey
+            var firstCTConfig = Config.ClaimTypes.FirstOrDefault(x => !String.IsNullOrEmpty(x.ClaimType));
+            firstCTConfig.EntityDataKey = entityDataKey;
+            ClaimTypeConfig ctConfig = new ClaimTypeConfig() { ClaimType = NonExistingClaimType, EntityDataKey = entityDataKey, DirectoryObjectProperty = AzureADObjectProperty.OfficeLocation };
+            Assert.Throws<InvalidOperationException>(() => Config.Update());
+        }
+    }
+}

--- a/AzureCP.Tests/ModifyConfigTests.cs
+++ b/AzureCP.Tests/ModifyConfigTests.cs
@@ -26,58 +26,57 @@ namespace AzureCP.Tests
         {
             ClaimTypeConfig ctConfig = new ClaimTypeConfig();
 
-            // Adding a ClaimTypeConfig with a claim type already set should fail
+            // Add a ClaimTypeConfig with a claim type already set should throw exception InvalidOperationException
             ctConfig.ClaimType = UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType;
             ctConfig.DirectoryObjectProperty = UnitTestsHelper.RandomObjectProperty;
-            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig), $"Adding a ClaimTypeConfig with a claim type already set should throw exception InvalidOperationException with this message: \"Claim type '{UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType}' already exists in the collection\"");
+            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig), $"Add a ClaimTypeConfig with a claim type already set should throw exception InvalidOperationException with this message: \"Claim type '{UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType}' already exists in the collection\"");
 
-            // Adding a ClaimTypeConfig with UseMainClaimTypeOfDirectoryObject = false (default value) and DirectoryObjectProperty not set should fail
+            // Add a ClaimTypeConfig with UseMainClaimTypeOfDirectoryObject = false (default value) and DirectoryObjectProperty not set should throw exception InvalidOperationException
             ctConfig.ClaimType = UnitTestsHelper.RandomClaimType;
             ctConfig.DirectoryObjectProperty = AzureADObjectProperty.NotSet;
-            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig), $"Adding a ClaimTypeConfig with a claim type already set should throw exception InvalidOperationException with this message: \"Property DirectoryObjectProperty is required\"");
+            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig), $"Add a ClaimTypeConfig with UseMainClaimTypeOfDirectoryObject = false (default value) and DirectoryObjectProperty not set should throw exception InvalidOperationException with this message: \"Property DirectoryObjectProperty is required\"");
 
-            // Adding a ClaimTypeConfig with UseMainClaimTypeOfDirectoryObject = true and ClaimType set should fail
+            // Add a ClaimTypeConfig with UseMainClaimTypeOfDirectoryObject = true and ClaimType set should throw exception InvalidOperationException
             ctConfig.ClaimType = UnitTestsHelper.RandomClaimType;
             ctConfig.DirectoryObjectProperty = UnitTestsHelper.RandomObjectProperty;
             ctConfig.UseMainClaimTypeOfDirectoryObject = true;
-            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig), $"Adding a ClaimTypeConfig with a claim type already set should throw exception InvalidOperationException with this message: \"No claim type should be set if UseMainClaimTypeOfDirectoryObject is set to true\"");
+            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig), $"Add a ClaimTypeConfig with UseMainClaimTypeOfDirectoryObject = true and ClaimType set should throw exception InvalidOperationException with this message: \"No claim type should be set if UseMainClaimTypeOfDirectoryObject is set to true\"");
 
-            // Adding a ClaimTypeConfig with EntityType 'Group' should fail since 1 already exists by default and AzureCP allows only 1 claim type for EntityType 'Group'
+            // Add a ClaimTypeConfig with EntityType 'Group' should throw exception InvalidOperationException since 1 already exists by default and AzureCP allows only 1 claim type for EntityType 'Group'
             ctConfig.ClaimType = UnitTestsHelper.RandomClaimType;
             ctConfig.DirectoryObjectProperty = UnitTestsHelper.RandomObjectProperty;
             ctConfig.EntityType = DirectoryObjectType.Group;
             ctConfig.UseMainClaimTypeOfDirectoryObject = false;
-            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig), $"Adding a ClaimTypeConfig with a claim type already set should throw exception InvalidOperationException with this message: \"A claim type for EntityType 'Group' already exists in the collection\"");
+            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig), $"Add a ClaimTypeConfig with EntityType 'Group' should throw exception InvalidOperationException with this message: \"A claim type for EntityType 'Group' already exists in the collection\"");
 
-            // Adding a valid ClaimTypeConfig should succeed
+            // Add a valid ClaimTypeConfig should succeed
             ctConfig.ClaimType = UnitTestsHelper.RandomClaimType;
             ctConfig.DirectoryObjectProperty = UnitTestsHelper.RandomObjectProperty;
             ctConfig.EntityType = DirectoryObjectType.User;
             ctConfig.UseMainClaimTypeOfDirectoryObject = false;
-            Assert.DoesNotThrow(() => Config.ClaimTypes.Add(ctConfig), $"ClaimTypeConfig {UnitTestsHelper.RandomClaimType} should have been added successfully but was not");
+            Assert.DoesNotThrow(() => Config.ClaimTypes.Add(ctConfig), $"Add a valid ClaimTypeConfig should succeed");
 
-            // Adding a ClaimTypeConfig twice should fail
-            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig), $"Adding a ClaimTypeConfig with a claim type already set should throw exception InvalidOperationException with this message: \"Claim type '{UnitTestsHelper.RandomClaimType}' already exists in the collection\"");
+            // Add a ClaimTypeConfig twice should throw exception InvalidOperationException
+            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig), $"Add a ClaimTypeConfig with a claim type already set should throw exception InvalidOperationException with this message: \"Claim type '{UnitTestsHelper.RandomClaimType}' already exists in the collection\"");
 
-            // Deleting the ClaimTypeConfig should succeed
-            Assert.IsTrue(Config.ClaimTypes.Remove(ctConfig), $"ClaimTypeConfig {UnitTestsHelper.RandomClaimType} should have been removed successfully but was not");
+            // Delete the ClaimTypeConfig by calling method ClaimTypeConfigCollection.Remove(ClaimTypeConfig) should succeed
+            Assert.IsTrue(Config.ClaimTypes.Remove(ctConfig), $"Delete the ClaimTypeConfig by calling method ClaimTypeConfigCollection.Remove(ClaimTypeConfig) should succeed");
         }
 
         [Test]
         public void ModifyOrDeleteIdentityClaimTypeConfig()
         {
-            // Deleting identity claim type from ClaimTypes list based on its claim type should fail
+            // Delete identity claim type from ClaimTypes list based on its claim type should throw exception InvalidOperationException
             string identityClaimType = UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType;
-            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Remove(identityClaimType), $"Deleting identity claim type from ClaimTypes list should throw exception InvalidOperationException with this message: \"Cannot delete claim type \"{UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType}\" because it is the identity claim type of \"{UnitTestsHelper.SPTrust.Name}\"\"");
+            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Remove(identityClaimType), $"Delete identity claim type from ClaimTypes list should throw exception InvalidOperationException with this message: \"Cannot delete claim type \"{UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType}\" because it is the identity claim type of \"{UnitTestsHelper.SPTrust.Name}\"\"");
 
-            // Deleting identity claim type from ClaimTypes list based on its ClaimTypeConfig should fail
+            // Delete identity claim type from ClaimTypes list based on its ClaimTypeConfig should throw exception InvalidOperationException
             ClaimTypeConfig identityCTConfig = Config.ClaimTypes.FirstOrDefault(x => String.Equals(UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType, x.ClaimType, StringComparison.InvariantCultureIgnoreCase));
-            Assert.IsNotNull(identityCTConfig);
-            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Remove(identityClaimType), $"Deleting identity claim type from ClaimTypes list should throw exception InvalidOperationException with this message: \"Cannot delete claim type \"{UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType}\" because it is the identity claim type of \"{UnitTestsHelper.SPTrust.Name}\"\"");
+            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Remove(identityClaimType), $"Delete identity claim type from ClaimTypes list should throw exception InvalidOperationException with this message: \"Cannot delete claim type \"{UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType}\" because it is the identity claim type of \"{UnitTestsHelper.SPTrust.Name}\"\"");
 
-            // Modify identity ClaimTypeConfig to set its EntityType to Group should fail
+            // Modify identity ClaimTypeConfig to set its EntityType to Group should throw exception InvalidOperationException
             identityCTConfig.EntityType = DirectoryObjectType.Group;
-            Assert.Throws<InvalidOperationException>(() => Config.Update(), $"Modifying identity claim type to set its EntityType to Group should throw exception InvalidOperationException with this message: \"{ConfigUpdateErrorMessage}\"");
+            Assert.Throws<InvalidOperationException>(() => Config.Update(), $"Modify identity claim type to set its EntityType to Group should throw exception InvalidOperationException with this message: \"{ConfigUpdateErrorMessage}\"");
         }
 
         [Test]
@@ -85,14 +84,14 @@ namespace AzureCP.Tests
         {
             var firstCTConfig = Config.ClaimTypes.FirstOrDefault(x => !String.IsNullOrEmpty(x.ClaimType));
 
-            // Setting a duplicate claim type on a new item should fail
-            ClaimTypeConfig ctConfig = new ClaimTypeConfig() { ClaimType = firstCTConfig.ClaimType, DirectoryObjectProperty = AzureADObjectProperty.OfficeLocation };
-            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig), $"Adding a ClaimTypeConfig with property ClaimType already defined in another ClaimTypeConfig should throw exception InvalidOperationException with this message: \"Claim type '{firstCTConfig.ClaimType}' already exists in the collection\"");
+            // Add a ClaimTypeConfig with property ClaimType already defined in another ClaimTypeConfig should throw exception InvalidOperationException
+            ClaimTypeConfig ctConfig = new ClaimTypeConfig() { ClaimType = firstCTConfig.ClaimType, DirectoryObjectProperty = UnitTestsHelper.RandomObjectProperty };
+            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig), $"Add a ClaimTypeConfig with property ClaimType already defined in another ClaimTypeConfig should throw exception InvalidOperationException with this message: \"Claim type '{firstCTConfig.ClaimType}' already exists in the collection\"");
 
-            // Setting a duplicate claim type on items already existing in the list should fail
+            // Modify an existing claim type to set a claim type already defined should throw exception InvalidOperationException
             ClaimTypeConfig anotherCTConfig = Config.ClaimTypes.FirstOrDefault(x => !String.IsNullOrEmpty(x.ClaimType) && !String.Equals(firstCTConfig.ClaimType, x.ClaimType, StringComparison.InvariantCultureIgnoreCase));
             anotherCTConfig.ClaimType = firstCTConfig.ClaimType;
-            Assert.Throws<InvalidOperationException>(() => Config.Update(), $"Modifying an existing claim type to set a claim type already defined should throw exception InvalidOperationException with this message: \"{ConfigUpdateErrorMessage}\"");
+            Assert.Throws<InvalidOperationException>(() => Config.Update(), $"Modify an existing claim type to set a claim type already defined should throw exception InvalidOperationException with this message: \"{ConfigUpdateErrorMessage}\"");
         }
 
         [Test]
@@ -100,15 +99,15 @@ namespace AzureCP.Tests
         {
             string prefixToBypassLookup = "test:";
 
-            // Setting a duplicate PrefixToBypassLookup on 2 items already existing in the list should fail
+            // Set a duplicate PrefixToBypassLookup on 2 items already existing in the list should throw exception InvalidOperationException
             Config.ClaimTypes.Where(x => !String.IsNullOrEmpty(x.ClaimType)).Take(2).Select(x => x.PrefixToBypassLookup = prefixToBypassLookup).ToList();
-            Assert.Throws<InvalidOperationException>(() => Config.Update(), $"Setting a duplicate PrefixToBypassLookup on 2 items already existing in the list should throw exception InvalidOperationException with this message: \"{ConfigUpdateErrorMessage}\"");
+            Assert.Throws<InvalidOperationException>(() => Config.Update(), $"Set a duplicate PrefixToBypassLookup on 2 items already existing in the list should throw exception InvalidOperationException with this message: \"{ConfigUpdateErrorMessage}\"");
 
-            // Setting a PrefixToBypassLookup on an existing item and add a new item with the same PrefixToBypassLookup should fail
+            // Set a PrefixToBypassLookup on an existing item and add a new item with the same PrefixToBypassLookup should throw exception InvalidOperationException
             var firstCTConfig = Config.ClaimTypes.FirstOrDefault(x => !String.IsNullOrEmpty(x.ClaimType));
             firstCTConfig.PrefixToBypassLookup = prefixToBypassLookup;
-            ClaimTypeConfig ctConfig = new ClaimTypeConfig() { ClaimType = UnitTestsHelper.RandomClaimType, PrefixToBypassLookup = prefixToBypassLookup, DirectoryObjectProperty = AzureADObjectProperty.OfficeLocation };
-            Assert.Throws<InvalidOperationException>(() => Config.Update(), $"Setting a duplicate PrefixToBypassLookup on an existing item and add a new item with the same PrefixToBypassLookup should throw exception InvalidOperationException with this message: \"{ConfigUpdateErrorMessage}\"");
+            ClaimTypeConfig ctConfig = new ClaimTypeConfig() { ClaimType = UnitTestsHelper.RandomClaimType, PrefixToBypassLookup = prefixToBypassLookup, DirectoryObjectProperty = UnitTestsHelper.RandomObjectProperty };
+            Assert.Throws<InvalidOperationException>(() => Config.Update(), $"Set a duplicate PrefixToBypassLookup on an existing item and add a new item with the same PrefixToBypassLookup should throw exception InvalidOperationException with this message: \"{ConfigUpdateErrorMessage}\"");
         }
 
         [Test]
@@ -116,15 +115,15 @@ namespace AzureCP.Tests
         {
             string entityDataKey = "test";
 
-            // Setting a duplicate EntityDataKey on 2 items already existing in the list should fail
+            // Duplicate EntityDataKey on 2 items already existing in the list should throw exception InvalidOperationException
             Config.ClaimTypes.Where(x => x.EntityType == DirectoryObjectType.User).Take(2).Select(x => x.EntityDataKey = entityDataKey).ToList();
-            Assert.Throws<InvalidOperationException>(() => Config.Update(), $"Setting a duplicate EntityDataKey on 2 items already existing in the list should throw exception InvalidOperationException with this message: \"{ConfigUpdateErrorMessage}\"");
+            Assert.Throws<InvalidOperationException>(() => Config.Update(), $"Duplicate EntityDataKey on 2 items already existing in the list should throw exception InvalidOperationException with this message: \"{ConfigUpdateErrorMessage}\"");
 
-            // Setting a EntityDataKey on an existing item and add a new item with the same EntityDataKey should fail
-            var firstCTConfig = Config.ClaimTypes.FirstOrDefault(x => !String.IsNullOrEmpty(x.ClaimType));
-            firstCTConfig.EntityDataKey = entityDataKey;
+            // Remove one of the duplicated EntityDataKey
+            Config.ClaimTypes.FirstOrDefault(x => x.EntityDataKey == entityDataKey).EntityDataKey = String.Empty;
+            // Set an EntityDataKey on an existing item and add a new item with the same EntityDataKey should throw exception InvalidOperationException
             ClaimTypeConfig ctConfig = new ClaimTypeConfig() { ClaimType = UnitTestsHelper.RandomClaimType, EntityDataKey = entityDataKey, DirectoryObjectProperty = UnitTestsHelper.RandomObjectProperty };
-            Assert.Throws<InvalidOperationException>(() => Config.Update(), $"Setting a EntityDataKey on an existing item and add a new item with the same EntityDataKey should throw exception InvalidOperationException with this message: \"{ConfigUpdateErrorMessage}\"");
+            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig), $"Set an EntityDataKey on an existing item and add a new item with the same EntityDataKey should throw exception InvalidOperationException with this message: \"Entity metadata '{entityDataKey}' already exists in the collection for the directory object User\"");
         }
 
         [Test]
@@ -132,17 +131,20 @@ namespace AzureCP.Tests
         {
             ClaimTypeConfig existingCTConfig = Config.ClaimTypes.FirstOrDefault(x => !String.IsNullOrEmpty(x.ClaimType) && x.EntityType == DirectoryObjectType.User);
 
-            // Create a new ClaimTypeConfig with a DirectoryObjectProperty already set should fail
+            // Create a new ClaimTypeConfig with a DirectoryObjectProperty already set should throw exception InvalidOperationException
             ClaimTypeConfig ctConfig = new ClaimTypeConfig() { ClaimType = UnitTestsHelper.RandomClaimType, EntityType = DirectoryObjectType.User, DirectoryObjectProperty = existingCTConfig.DirectoryObjectProperty };
-            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig));
+            Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig), $"Create a new ClaimTypeConfig with a DirectoryObjectProperty already set should throw exception InvalidOperationException with this message: \"An item with property '{existingCTConfig.DirectoryObjectProperty.ToString()}' already exists for the object type 'User'\"");
 
-            // Should be added successfully (for next test)
+            // Add a valid ClaimTypeConfig should succeed (done for next test)
             ctConfig.DirectoryObjectProperty = UnitTestsHelper.RandomObjectProperty;
-            Assert.DoesNotThrow(() => Config.ClaimTypes.Add(ctConfig));
+            Assert.DoesNotThrow(() => Config.ClaimTypes.Add(ctConfig), $"Add a valid ClaimTypeConfig should succeed");
 
-            // Update an existing ClaimTypeConfig with a DirectoryObjectProperty already set should fail
+            // Update an existing ClaimTypeConfig with a DirectoryObjectProperty already set should throw exception InvalidOperationException
             ctConfig.DirectoryObjectProperty = existingCTConfig.DirectoryObjectProperty;
-            Assert.Throws<InvalidOperationException>(() => Config.Update());
+            Assert.Throws<InvalidOperationException>(() => Config.Update(), $"Update an existing ClaimTypeConfig with a DirectoryObjectProperty already set should throw exception InvalidOperationException with this message: \"{ConfigUpdateErrorMessage}\"");
+
+            // Delete the ClaimTypeConfig should succeed
+            Assert.IsTrue(Config.ClaimTypes.Remove(ctConfig), "Delete the ClaimTypeConfig should succeed");
         }
     }
 }

--- a/AzureCP.Tests/ModifyConfigTests.cs
+++ b/AzureCP.Tests/ModifyConfigTests.cs
@@ -14,7 +14,7 @@ namespace AzureCP.Tests
         [OneTimeSetUp]
         public void Init()
         {
-            AzureCPConfig configFromConfigDB = AzureCPConfig.GetConfiguration(UnitTestsHelper.ClaimsProviderConfigName);
+            AzureCPConfig configFromConfigDB = AzureCPConfig.GetConfiguration(UnitTestsHelper.ClaimsProviderConfigName, UnitTestsHelper.SPTrust.Name);
             // Create a local copy, otherwise changes will impact the whole process (even without calling Update method)
             Config = configFromConfigDB.CopyPersistedProperties();
             // Reset configuration to test its default for the tests

--- a/AzureCP.Tests/ModifyConfigTests.cs
+++ b/AzureCP.Tests/ModifyConfigTests.cs
@@ -8,15 +8,12 @@ namespace AzureCP.Tests
     [TestFixture]
     public class ModifyConfigTests
     {
-        public const string ClaimsProviderConfigName = "AzureCPConfig";
-        public const string AvailableClaimType = "http://schemas.yvand.com/ws/claims/random";
-        public const AzureADObjectProperty AvailableObjectProperty = AzureADObjectProperty.AccountEnabled;
         private AzureCPConfig Config;
 
         [OneTimeSetUp]
         public void Init()
         {
-            AzureCPConfig configFromConfigDB = AzureCPConfig.GetConfiguration(ClaimsProviderConfigName);
+            AzureCPConfig configFromConfigDB = AzureCPConfig.GetConfiguration(UnitTestsHelper.ClaimsProviderConfigName);
             // Create a local copy, otherwise changes will impact the whole process (even without calling Update method)
             Config = configFromConfigDB.CopyPersistedProperties();
             // Reset configuration to test its default for the tests
@@ -30,30 +27,30 @@ namespace AzureCP.Tests
 
             // Adding a ClaimTypeConfig with a claim type already set should fail
             ctConfig.ClaimType = UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType;
-            ctConfig.DirectoryObjectProperty = AvailableObjectProperty;
+            ctConfig.DirectoryObjectProperty = UnitTestsHelper.RandomObjectProperty;
             Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig));
 
             // Adding a ClaimTypeConfig with UseMainClaimTypeOfDirectoryObject = false (default value) and DirectoryObjectProperty not set should fail
-            ctConfig.ClaimType = AvailableClaimType;
+            ctConfig.ClaimType = UnitTestsHelper.RandomClaimType;
             ctConfig.DirectoryObjectProperty = AzureADObjectProperty.NotSet;
             Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig));
 
             // Adding a ClaimTypeConfig with UseMainClaimTypeOfDirectoryObject = true and ClaimType set should fail
-            ctConfig.ClaimType = AvailableClaimType;
-            ctConfig.DirectoryObjectProperty = AvailableObjectProperty;
+            ctConfig.ClaimType = UnitTestsHelper.RandomClaimType;
+            ctConfig.DirectoryObjectProperty = UnitTestsHelper.RandomObjectProperty;
             ctConfig.UseMainClaimTypeOfDirectoryObject = true;
             Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig));
 
             // Adding a ClaimTypeConfig with EntityType 'Group' should fail since 1 already exists by default and AzureCP allows only 1 claim type for EntityType 'Group'
-            ctConfig.ClaimType = AvailableClaimType;
-            ctConfig.DirectoryObjectProperty = AvailableObjectProperty;
+            ctConfig.ClaimType = UnitTestsHelper.RandomClaimType;
+            ctConfig.DirectoryObjectProperty = UnitTestsHelper.RandomObjectProperty;
             ctConfig.EntityType = DirectoryObjectType.Group;
             ctConfig.UseMainClaimTypeOfDirectoryObject = false;
             Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig));
 
             // Adding a valid ClaimTypeConfig should succeed
-            ctConfig.ClaimType = AvailableClaimType;
-            ctConfig.DirectoryObjectProperty = AvailableObjectProperty;
+            ctConfig.ClaimType = UnitTestsHelper.RandomClaimType;
+            ctConfig.DirectoryObjectProperty = UnitTestsHelper.RandomObjectProperty;
             ctConfig.EntityType = DirectoryObjectType.User;
             ctConfig.UseMainClaimTypeOfDirectoryObject = false;
             Assert.DoesNotThrow(() => Config.ClaimTypes.Add(ctConfig));
@@ -109,7 +106,7 @@ namespace AzureCP.Tests
             // Setting a PrefixToBypassLookup on an existing item and add a new item with the same PrefixToBypassLookup should fail
             var firstCTConfig = Config.ClaimTypes.FirstOrDefault(x => !String.IsNullOrEmpty(x.ClaimType));
             firstCTConfig.PrefixToBypassLookup = prefixToBypassLookup;
-            ClaimTypeConfig ctConfig = new ClaimTypeConfig() { ClaimType = AvailableClaimType, PrefixToBypassLookup = prefixToBypassLookup, DirectoryObjectProperty = AzureADObjectProperty.OfficeLocation };
+            ClaimTypeConfig ctConfig = new ClaimTypeConfig() { ClaimType = UnitTestsHelper.RandomClaimType, PrefixToBypassLookup = prefixToBypassLookup, DirectoryObjectProperty = AzureADObjectProperty.OfficeLocation };
             Assert.Throws<InvalidOperationException>(() => Config.Update());
         }
 
@@ -125,7 +122,7 @@ namespace AzureCP.Tests
             // Setting a EntityDataKey on an existing item and add a new item with the same EntityDataKey should fail
             var firstCTConfig = Config.ClaimTypes.FirstOrDefault(x => !String.IsNullOrEmpty(x.ClaimType));
             firstCTConfig.EntityDataKey = entityDataKey;
-            ClaimTypeConfig ctConfig = new ClaimTypeConfig() { ClaimType = AvailableClaimType, EntityDataKey = entityDataKey, DirectoryObjectProperty = AvailableObjectProperty };
+            ClaimTypeConfig ctConfig = new ClaimTypeConfig() { ClaimType = UnitTestsHelper.RandomClaimType, EntityDataKey = entityDataKey, DirectoryObjectProperty = UnitTestsHelper.RandomObjectProperty };
             Assert.Throws<InvalidOperationException>(() => Config.Update());
         }
 
@@ -135,11 +132,11 @@ namespace AzureCP.Tests
             ClaimTypeConfig existingCTConfig = Config.ClaimTypes.FirstOrDefault(x => !String.IsNullOrEmpty(x.ClaimType) && x.EntityType == DirectoryObjectType.User);
 
             // Create a new ClaimTypeConfig with a DirectoryObjectProperty already set should fail
-            ClaimTypeConfig ctConfig = new ClaimTypeConfig() { ClaimType = AvailableClaimType, EntityType = DirectoryObjectType.User, DirectoryObjectProperty = existingCTConfig.DirectoryObjectProperty };
+            ClaimTypeConfig ctConfig = new ClaimTypeConfig() { ClaimType = UnitTestsHelper.RandomClaimType, EntityType = DirectoryObjectType.User, DirectoryObjectProperty = existingCTConfig.DirectoryObjectProperty };
             Assert.Throws<InvalidOperationException>(() => Config.ClaimTypes.Add(ctConfig));
 
             // Should be added successfully (for next test)
-            ctConfig.DirectoryObjectProperty = AvailableObjectProperty;
+            ctConfig.DirectoryObjectProperty = UnitTestsHelper.RandomObjectProperty;
             Assert.DoesNotThrow(() => Config.ClaimTypes.Add(ctConfig));
 
             // Update an existing ClaimTypeConfig with a DirectoryObjectProperty already set should fail

--- a/AzureCP.Tests/PeoplePickerTests.cs
+++ b/AzureCP.Tests/PeoplePickerTests.cs
@@ -31,7 +31,7 @@ namespace AzureCP.Tests
             UnitTestsHelper.TestSearchOperation(inputValue, Convert.ToInt32(expectedCount), expectedClaimValue);
         }
 
-        //[TestCase(@"AADGroup1", 1, "5b0f6c56-c87f-44c3-9354-56cba03da433")]
+        [TestCase(@"AADGroup1", 1, "5b0f6c56-c87f-44c3-9354-56cba03da433")]
         public void DEBUG_SearchEntities(string inputValue, int expectedResultCount, string expectedEntityClaimValue)
         {
             UnitTestsHelper.TestSearchOperation(inputValue, expectedResultCount, expectedEntityClaimValue);

--- a/AzureCP.Tests/PeoplePickerTests.cs
+++ b/AzureCP.Tests/PeoplePickerTests.cs
@@ -13,8 +13,7 @@ namespace AzureCP.Tests
         [Test, TestCaseSource(typeof(SearchEntityDataSource), "GetTestData")]
         public void SearchEntities(SearchEntityData registrationData)
         {
-            SPProviderHierarchyTree[] providerResults = UnitTestsHelper.DoSearchOperation(registrationData.Input);
-            UnitTestsHelper.VerifySearchResult(providerResults, registrationData.ExpectedResultCount, registrationData.ExpectedEntityClaimValue);
+            UnitTestsHelper.TestSearchOperation(registrationData.Input, registrationData.ExpectedResultCount, registrationData.ExpectedEntityClaimValue);
         }
 
         [Test, TestCaseSource(typeof(ValidateEntityDataSource), "GetTestData")]
@@ -23,30 +22,26 @@ namespace AzureCP.Tests
         public void ValidateClaim(ValidateEntityData registrationData)
         {
             SPClaim inputClaim = new SPClaim(UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType, registrationData.ClaimValue, ClaimValueTypes.String, SPOriginalIssuers.Format(SPOriginalIssuerType.TrustedProvider, UnitTestsHelper.SPTrust.Name));
-            PickerEntity[] entities = UnitTestsHelper.DoValidationOperation(inputClaim);
-            UnitTestsHelper.VerifyValidationResult(entities, registrationData.ShouldValidate, registrationData.ClaimValue);
+            UnitTestsHelper.TestValidationOperation(inputClaim, registrationData.ShouldValidate, registrationData.ClaimValue);
         }
 
         //[TestCaseSource(typeof(SearchEntityDataSourceCollection))]
         public void DEBUG_SearchEntitiesFromCollection(string inputValue, string expectedCount, string expectedClaimValue)
         {
-            SPProviderHierarchyTree[] providerResults = UnitTestsHelper.DoSearchOperation(inputValue);
-            UnitTestsHelper.VerifySearchResult(providerResults, Convert.ToInt32(expectedCount), expectedClaimValue);
+            UnitTestsHelper.TestSearchOperation(inputValue, Convert.ToInt32(expectedCount), expectedClaimValue);
         }
 
         //[TestCase(@"AADGroup1", 1, "5b0f6c56-c87f-44c3-9354-56cba03da433")]
         public void DEBUG_SearchEntities(string inputValue, int expectedResultCount, string expectedEntityClaimValue)
         {
-            SPProviderHierarchyTree[] providerResults = UnitTestsHelper.DoSearchOperation(inputValue);
-            UnitTestsHelper.VerifySearchResult(providerResults, expectedResultCount, expectedEntityClaimValue);
+            UnitTestsHelper.TestSearchOperation(inputValue, expectedResultCount, expectedEntityClaimValue);
         }
 
         //[TestCase("http://schemas.microsoft.com/ws/2008/06/identity/claims/role", "5b0f6c56-c87f-44c3-9354-56cba03da433", true)]
         public void DEBUG_ValidateClaim(string claimType, string claimValue, bool shouldValidate)
         {
             SPClaim inputClaim = new SPClaim(claimType, claimValue, ClaimValueTypes.String, SPOriginalIssuers.Format(SPOriginalIssuerType.TrustedProvider, UnitTestsHelper.SPTrust.Name));
-            PickerEntity[] entities = UnitTestsHelper.DoValidationOperation(inputClaim);
-            UnitTestsHelper.VerifyValidationResult(entities, shouldValidate, claimValue);
+            UnitTestsHelper.TestValidationOperation(inputClaim, shouldValidate, claimValue);
         }
     }    
 }

--- a/AzureCP.Tests/PeoplePickerTests.cs
+++ b/AzureCP.Tests/PeoplePickerTests.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.SharePoint.Administration.Claims;
+using Microsoft.SharePoint.WebControls;
+using NUnit.Framework;
+using System;
+using System.Security.Claims;
+
+namespace AzureCP.Tests
+{
+    [TestFixture]
+    [Parallelizable(ParallelScope.Children)]
+    public class PeoplePickerTests
+    {
+        [Test, TestCaseSource(typeof(SearchEntityDataSource), "GetTestData")]
+        public void SearchEntities(SearchEntityData registrationData)
+        {
+            SPProviderHierarchyTree[] providerResults = UnitTestsHelper.DoSearchOperation(registrationData.Input);
+            UnitTestsHelper.VerifySearchResult(providerResults, registrationData.ExpectedResultCount, registrationData.ExpectedEntityClaimValue);
+        }
+
+        [Test, TestCaseSource(typeof(ValidateEntityDataSource), "GetTestData")]
+        [MaxTime(UnitTestsHelper.MaxTime)]
+        [Repeat(UnitTestsHelper.TestRepeatCount)]
+        public void ValidateClaim(ValidateEntityData registrationData)
+        {
+            SPClaim inputClaim = new SPClaim(UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType, registrationData.ClaimValue, ClaimValueTypes.String, SPOriginalIssuers.Format(SPOriginalIssuerType.TrustedProvider, UnitTestsHelper.SPTrust.Name));
+            PickerEntity[] entities = UnitTestsHelper.DoValidationOperation(inputClaim);
+            UnitTestsHelper.VerifyValidationResult(entities, registrationData.ShouldValidate, registrationData.ClaimValue);
+        }
+
+        //[TestCaseSource(typeof(SearchEntityDataSourceCollection))]
+        public void DEBUG_SearchEntitiesFromCollection(string inputValue, string expectedCount, string expectedClaimValue)
+        {
+            SPProviderHierarchyTree[] providerResults = UnitTestsHelper.DoSearchOperation(inputValue);
+            UnitTestsHelper.VerifySearchResult(providerResults, Convert.ToInt32(expectedCount), expectedClaimValue);
+        }
+
+        //[TestCase(@"AADGroup1", 1, "5b0f6c56-c87f-44c3-9354-56cba03da433")]
+        public void DEBUG_SearchEntities(string inputValue, int expectedResultCount, string expectedEntityClaimValue)
+        {
+            SPProviderHierarchyTree[] providerResults = UnitTestsHelper.DoSearchOperation(inputValue);
+            UnitTestsHelper.VerifySearchResult(providerResults, expectedResultCount, expectedEntityClaimValue);
+        }
+
+        //[TestCase("http://schemas.microsoft.com/ws/2008/06/identity/claims/role", "5b0f6c56-c87f-44c3-9354-56cba03da433", true)]
+        public void DEBUG_ValidateClaim(string claimType, string claimValue, bool shouldValidate)
+        {
+            SPClaim inputClaim = new SPClaim(claimType, claimValue, ClaimValueTypes.String, SPOriginalIssuers.Format(SPOriginalIssuerType.TrustedProvider, UnitTestsHelper.SPTrust.Name));
+            PickerEntity[] entities = UnitTestsHelper.DoValidationOperation(inputClaim);
+            UnitTestsHelper.VerifyValidationResult(entities, shouldValidate, claimValue);
+        }
+    }    
+}

--- a/AzureCP.Tests/Properties/AssemblyInfo.cs
+++ b/AzureCP.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("AzureCP.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("AzureCP.Tests")]
+[assembly: AssemblyCopyright("Copyright © Microsoft Corporation 2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("db8c79e5-f7f7-4841-8a8c-a9832a9cae88")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/AzureCP.Tests/UnitTestsHelper.cs
+++ b/AzureCP.Tests/UnitTestsHelper.cs
@@ -92,28 +92,28 @@ public class UnitTestsHelper
         {
             entities.AddRange(children.EntityData);
         }
-        VerifySearchTest(entities, expectedCount, expectedClaimValue);
+        VerifySearchTest(entities, inputValue, expectedCount, expectedClaimValue);
 
         entities = ClaimsProvider.Resolve(Context, entityTypes, inputValue).ToList();
-        VerifySearchTest(entities, expectedCount, expectedClaimValue);
+        VerifySearchTest(entities, inputValue, expectedCount, expectedClaimValue);
     }
 
-    public static void VerifySearchTest(List<PickerEntity> entities, int expectedCount, string expectedClaimValue)
+    public static void VerifySearchTest(List<PickerEntity> entities, string input, int expectedCount, string expectedClaimValue)
     {
-        int nbEntity = 0;
         bool entityValueFound = false;
-
         foreach (PickerEntity entity in entities)
         {
-            nbEntity++;
             if (String.Equals(expectedClaimValue, entity.Claim.Value, StringComparison.InvariantCultureIgnoreCase))
             {
                 entityValueFound = true;
             }
         }
-        if (!entityValueFound && expectedCount > 0) Assert.Fail($"No entity with claim value {expectedClaimValue} was found in the entities returned by {UnitTestsHelper.ClaimsProviderName}");
 
-        Assert.AreEqual(expectedCount, nbEntity);
+        if (!entityValueFound && expectedCount > 0)
+        {
+            Assert.Fail($"Input \"{input}\" returned no entity with claim value \"{expectedClaimValue}\".");
+        }
+        Assert.AreEqual(expectedCount, entities.Count, $"Input \"{input}\" should have returned {expectedCount} entities, but it returned {entities.Count} instead.");
     }
 
     public static void TestValidationOperation(SPClaim inputClaim, bool shouldValidate, string expectedClaimValue)
@@ -123,8 +123,11 @@ public class UnitTestsHelper
         PickerEntity[] entities = ClaimsProvider.Resolve(Context, entityTypes, inputClaim);
 
         int expectedCount = shouldValidate ? 1 : 0;
-        Assert.AreEqual(expectedCount, entities.Length);
-        if (shouldValidate) StringAssert.AreEqualIgnoringCase(expectedClaimValue, entities[0].Claim.Value);
+        Assert.AreEqual(expectedCount, entities.Length, $"Validation of entity \"{inputClaim.Value}\" should have returned {expectedCount} entity, but it returned {entities.Length} instead.");
+        if (shouldValidate)
+        {
+            StringAssert.AreEqualIgnoringCase(expectedClaimValue, entities[0].Claim.Value, $"Validation of entity \"{inputClaim.Value}\" should have returned value \"{expectedClaimValue}\", but it returned \"{entities[0].Claim.Value}\" instead.");
+        }
     }
 
     public static void TestAugmentationOperation(string claimType, string claimValue, bool isMemberOfTrustedGroup)
@@ -136,7 +139,10 @@ public class UnitTestsHelper
 
         bool groupFound = false;
         if (groups != null && groups.Contains(TrustedGroup)) groupFound = true;
-        if (isMemberOfTrustedGroup) Assert.IsTrue(groupFound);
+        if (isMemberOfTrustedGroup)
+        {
+            Assert.IsTrue(groupFound, $"Entity \"{claimValue}\" should be member of group \"{TrustedGroupToAdd_ClaimValue}\" but is not.");
+        }
     }
 }
 

--- a/AzureCP.Tests/UnitTestsHelper.cs
+++ b/AzureCP.Tests/UnitTestsHelper.cs
@@ -46,7 +46,7 @@ public class UnitTestsHelper
         AzureCPConfig config = AzureCPConfig.GetConfiguration(UnitTestsHelper.ClaimsProviderConfigName, UnitTestsHelper.SPTrust.Name);
         if (config == null)
         {
-            AzureCPConfig.CreateConfiguration(ClaimsProviderConstants.AZURECPCONFIG_ID, ClaimsProviderConstants.AZURECPCONFIG_NAME, SPTrust.Name);
+            AzureCPConfig.CreateConfiguration(ClaimsProviderConstants.CONFIG_ID, ClaimsProviderConstants.CONFIG_NAME, SPTrust.Name);
         }
 
         SPWebApplication wa = SPWebApplication.Lookup(Context);

--- a/AzureCP.Tests/UnitTestsHelper.cs
+++ b/AzureCP.Tests/UnitTestsHelper.cs
@@ -14,6 +14,7 @@ using System.Security.Claims;
 [SetUpFixture]
 public class UnitTestsHelper
 {
+    public static azurecp.AzureCP ClaimsProvider = new azurecp.AzureCP(UnitTestsHelper.ClaimsProviderName);
     public const string ClaimsProviderName = "AzureCP";
     public const string ClaimsProviderConfigName = "AzureCPConfig";
     public static Uri Context = new Uri("http://spsites/sites/AzureCP.UnitTests");
@@ -27,7 +28,7 @@ public class UnitTestsHelper
 
     public const string TrustedGroupToAdd_ClaimValue = "99abdc91-e6e0-475c-a0ba-5014f91de853";
     public const string TrustedGroupToAdd_ClaimType = "http://schemas.microsoft.com/ws/2008/06/identity/claims/role";
-    private static SPBasePermissions TrustedGroupToAdd_PermissionsAssigned = SPBasePermissions.EditListItems;
+    public static SPClaim TrustedGroup = new SPClaim(TrustedGroupToAdd_ClaimType, TrustedGroupToAdd_ClaimValue, ClaimValueTypes.String, SPOriginalIssuers.Format(SPOriginalIssuerType.TrustedProvider, SPTrust.Name));
 
     public const string DataFile_SearchTests = @"F:\Data\Dev\AzureCP_SearchTests_Data.csv";
     public const string DataFile_ValidationTests = @"F:\Data\Dev\AzureCP_ValidationTests_Data.csv";
@@ -53,8 +54,7 @@ public class UnitTestsHelper
         {
             Console.WriteLine($"Web app {wa.Name} found.");
             SPClaimProviderManager claimMgr = SPClaimProviderManager.Local;
-            SPClaim claim = new SPClaim(TrustedGroupToAdd_ClaimType, TrustedGroupToAdd_ClaimValue, ClaimValueTypes.String, SPOriginalIssuers.Format(SPOriginalIssuerType.TrustedProvider, SPTrust.Name));
-            string encodedClaim = claimMgr.EncodeClaim(claim);
+            string encodedClaim = claimMgr.EncodeClaim(TrustedGroup);
             SPUserInfo userInfo = new SPUserInfo { LoginName = encodedClaim, Name = TrustedGroupToAdd_ClaimValue };
 
             if (!SPSite.Exists(Context))
@@ -82,84 +82,61 @@ public class UnitTestsHelper
         }
     }
 
-    public static SPProviderHierarchyTree[] DoSearchOperation(string inputValue)
+    public static void TestSearchOperation(string inputValue, int expectedCount, string expectedClaimValue)
     {
-        SPClaimProviderOperationOptions mode = SPClaimProviderOperationOptions.DisableHierarchyAugmentation;
-        string[] providerNames = new string[] { "AllUsers", ClaimsProviderName, "AD" };
         string[] entityTypes = new string[] { "User", "SecGroup", "SharePointGroup", "System", "FormsRole" };
 
-        SPProviderHierarchyTree[] providerResults = SPClaimProviderOperations.Search(UnitTestsHelper.Context, mode, providerNames, entityTypes, inputValue, 30);
-        return providerResults;
-    }
-
-    public static PickerEntity[] DoValidationOperation(SPClaim inputClaim)
-    {
-        SPClaimProviderOperationOptions mode = SPClaimProviderOperationOptions.AllZones | SPClaimProviderOperationOptions.OverrideVisibleConfiguration;
-        string[] providerNames = null;
-        string[] entityTypes = new string[] { "User" };
-
-        PickerEntity[] entities = SPClaimProviderOperations.Resolve(UnitTestsHelper.Context, mode, providerNames, entityTypes, inputClaim);
-        return entities;
-    }
-
-    public static void DoAugmentationOperationAndVerifyResult(string claimType, string claimValue, bool shouldHavePermissions)
-    {
-        SPClaim inputClaim = new SPClaim(claimType, claimValue, ClaimValueTypes.String, SPOriginalIssuers.Format(SPOriginalIssuerType.TrustedProvider, UnitTestsHelper.SPTrust.Name));
-
-        using (SPSite site = new SPSite(UnitTestsHelper.Context.AbsoluteUri))
+        SPProviderHierarchyTree providerResults = ClaimsProvider.Search(Context, entityTypes, inputValue, null, 30);
+        List<PickerEntity> entities = new List<PickerEntity>();
+        foreach (var children in providerResults.Children)
         {
-            // SPSite.RootWeb should not be disposed: https://blogs.msdn.microsoft.com/rogerla/2008/10/04/updated-spsite-rootweb-dispose-guidance/
-            SPWeb rootWeb = site.RootWeb;
-            SPBasePermissions effectivePermissions = rootWeb.GetUserEffectivePermissions(inputClaim.ToEncodedString());
-            bool hasPermissions = (effectivePermissions & TrustedGroupToAdd_PermissionsAssigned) == TrustedGroupToAdd_PermissionsAssigned;
-            if (shouldHavePermissions) Assert.IsTrue(hasPermissions);
-            else Assert.IsFalse(hasPermissions);
+            entities.AddRange(children.EntityData);
         }
+        VerifySearchTest(entities, expectedCount, expectedClaimValue);
+
+        entities = ClaimsProvider.Resolve(Context, entityTypes, inputValue).ToList();
+        VerifySearchTest(entities, expectedCount, expectedClaimValue);
     }
 
-    public static void VerifySearchResult(SPProviderHierarchyTree[] providerResults, int expectedCount, string expectedClaimValue)
+    public static void VerifySearchTest(List<PickerEntity> entities, int expectedCount, string expectedClaimValue)
     {
-        foreach (SPProviderHierarchyTree providerResult in providerResults)
-        {
-            if (providerResult.ProviderName == UnitTestsHelper.ClaimsProviderName)
-            {
-                Assert.AreEqual(expectedCount, providerResult.Count);
+        int nbEntity = 0;
+        bool entityValueFound = false;
 
-                if (expectedCount == 0)
-                {
-                    return;
-                }
-                else if (expectedCount == 1)
-                {
-                    PickerEntity entity = providerResult.Children[0].EntityData[0];
-                    StringAssert.AreEqualIgnoringCase(expectedClaimValue, entity.Claim.Value);
-                    return;
-                }
-                else
-                {
-                    foreach (var children in providerResult.Children)
-                    {
-                        foreach (var entity in children.EntityData)
-                        {
-                            if (String.Equals(expectedClaimValue, entity.Claim.Value))
-                            {
-                                StringAssert.AreEqualIgnoringCase(expectedClaimValue, entity.Claim.Value);
-                                return;
-                            }
-                        }
-                    }
-                    Assert.Fail($"No entity with claim value {expectedClaimValue} was found in the entities returned by {UnitTestsHelper.ClaimsProviderName}");
-                }
+        foreach (PickerEntity entity in entities)
+        {
+            nbEntity++;
+            if (String.Equals(expectedClaimValue, entity.Claim.Value, StringComparison.InvariantCultureIgnoreCase))
+            {
+                entityValueFound = true;
             }
         }
-        Assert.AreEqual(expectedCount, 0);
+        if (!entityValueFound && expectedCount > 0) Assert.Fail($"No entity with claim value {expectedClaimValue} was found in the entities returned by {UnitTestsHelper.ClaimsProviderName}");
+
+        Assert.AreEqual(expectedCount, nbEntity);
     }
 
-    public static void VerifyValidationResult(PickerEntity[] entities, bool shouldValidate, string expectedClaimValue)
+    public static void TestValidationOperation(SPClaim inputClaim, bool shouldValidate, string expectedClaimValue)
     {
+        string[] entityTypes = new string[] { "User" };
+
+        PickerEntity[] entities = ClaimsProvider.Resolve(Context, entityTypes, inputClaim);
+
         int expectedCount = shouldValidate ? 1 : 0;
         Assert.AreEqual(expectedCount, entities.Length);
         if (shouldValidate) StringAssert.AreEqualIgnoringCase(expectedClaimValue, entities[0].Claim.Value);
+    }
+
+    public static void TestAugmentationOperation(string claimType, string claimValue, bool isMemberOfTrustedGroup)
+    {
+        SPClaim inputClaim = new SPClaim(claimType, claimValue, ClaimValueTypes.String, SPOriginalIssuers.Format(SPOriginalIssuerType.TrustedProvider, UnitTestsHelper.SPTrust.Name));
+        Uri context = new Uri(UnitTestsHelper.Context.AbsoluteUri);
+
+        SPClaim[] groups = ClaimsProvider.GetClaimsForEntity(context, inputClaim);
+
+        bool groupFound = false;
+        if (groups != null && groups.Contains(TrustedGroup)) groupFound = true;
+        if (isMemberOfTrustedGroup) Assert.IsTrue(groupFound);
     }
 }
 

--- a/AzureCP.Tests/UnitTestsHelper.cs
+++ b/AzureCP.Tests/UnitTestsHelper.cs
@@ -43,7 +43,7 @@ public class UnitTestsHelper
     {
         //return; // Uncommented when debugging AzureCP code from unit tests
 
-        AzureCPConfig config = AzureCPConfig.GetConfiguration(UnitTestsHelper.ClaimsProviderConfigName);
+        AzureCPConfig config = AzureCPConfig.GetConfiguration(UnitTestsHelper.ClaimsProviderConfigName, UnitTestsHelper.SPTrust.Name);
         if (config == null)
         {
             AzureCPConfig.CreateConfiguration(ClaimsProviderConstants.AZURECPCONFIG_ID, ClaimsProviderConstants.AZURECPCONFIG_NAME, SPTrust.Name);

--- a/AzureCP.Tests/UnitTestsHelper.cs
+++ b/AzureCP.Tests/UnitTestsHelper.cs
@@ -19,7 +19,7 @@ public class UnitTestsHelper
     public const string ClaimsProviderConfigName = "AzureCPConfig";
     public static Uri Context = new Uri("http://spsites/sites/AzureCP.UnitTests");
     public const int MaxTime = 50000;
-    public const int TestRepeatCount = 50;
+    public const int TestRepeatCount = 100;
     public const string FarmAdmin = @"i:0#.w|contoso\yvand";
 
     public const string RandomClaimType = "http://schemas.yvand.com/ws/claims/random";
@@ -138,11 +138,13 @@ public class UnitTestsHelper
         SPClaim[] groups = ClaimsProvider.GetClaimsForEntity(context, inputClaim);
 
         bool groupFound = false;
-        if (groups != null && groups.Contains(TrustedGroup)) groupFound = true;
+        if (groups != null && groups.Contains(TrustedGroup))
+            groupFound = true;
+
         if (isMemberOfTrustedGroup)
-        {
-            Assert.IsTrue(groupFound, $"Entity \"{claimValue}\" should be member of group \"{TrustedGroupToAdd_ClaimValue}\" but is not.");
-        }
+            Assert.IsTrue(groupFound, $"Entity \"{claimValue}\" should be member of group \"{TrustedGroupToAdd_ClaimValue}\", but this group was not found in the claims returned by the claims provider.");
+        else
+            Assert.IsFalse(groupFound, $"Entity \"{claimValue}\" should NOT be member of group \"{TrustedGroupToAdd_ClaimValue}\", but this group was found in the claims returned by the claims provider.");
     }
 }
 

--- a/AzureCP.Tests/UnitTestsHelper.cs
+++ b/AzureCP.Tests/UnitTestsHelper.cs
@@ -1,0 +1,221 @@
+﻿using DataAccess;
+using Microsoft.SharePoint;
+using Microsoft.SharePoint.Administration;
+using Microsoft.SharePoint.Administration.Claims;
+using Microsoft.SharePoint.WebControls;
+using NUnit.Framework;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+
+[SetUpFixture]
+public class UnitTestsHelper
+{
+    public const string ClaimsProviderName = "AzureCP";
+    public static Uri Context = new Uri("http://spsites/sites/AzureCP.UnitTests");
+    public const int MaxTime = 50000;
+    public const int TestRepeatCount = 50;
+    public const string FarmAdmin = @"i:0#.w|contoso\yvand";
+    public const string NonExistentClaimValue = "IDoNotExist";
+
+    public const string TrustedGroupToAdd_ClaimValue = "a5e76528-a305-4345-8481-af345ea56032";
+    public const string TrustedGroupToAdd_ClaimType = "http://schemas.microsoft.com/ws/2008/06/identity/claims/role";
+    private static SPBasePermissions TrustedGroupToAdd_PermissionsAssigned = SPBasePermissions.EditListItems;
+
+    public const string DataFile_SearchTests = @"F:\Data\Dev\AzureCP_SearchTests_Data.csv";
+    public const string DataFile_ValidationTests = @"F:\Data\Dev\AzureCP_ValidationTests_Data.csv";
+
+    public static SPTrustedLoginProvider SPTrust
+    {
+        get => SPSecurityTokenServiceManager.Local.TrustedLoginProviders.FirstOrDefault(x => String.Equals(x.ClaimProviderName, UnitTestsHelper.ClaimsProviderName, StringComparison.InvariantCultureIgnoreCase));
+    }
+
+    [OneTimeSetUp]
+    public static void CheckSiteCollection()
+    {
+        //return; // Uncommented when debugging AzureCP code from unit tests
+        SPWebApplication wa = SPWebApplication.Lookup(Context);
+        if (wa != null)
+        {
+            Console.WriteLine($"Web app {wa.Name} found.");
+            SPClaimProviderManager claimMgr = SPClaimProviderManager.Local;
+            SPClaim claim = new SPClaim(TrustedGroupToAdd_ClaimType, TrustedGroupToAdd_ClaimValue, "http://www.w3.org/2001/XMLSchema#string", SPOriginalIssuers.Format(SPOriginalIssuerType.TrustedProvider, SPTrust.Name));
+            string encodedClaim = claimMgr.EncodeClaim(claim);
+            SPUserInfo userInfo = new SPUserInfo { LoginName = encodedClaim, Name = TrustedGroupToAdd_ClaimValue };
+
+            if (!SPSite.Exists(Context))
+            {
+                Console.WriteLine($"Creating site collection {Context.AbsoluteUri}...");
+                SPSite spSite = wa.Sites.Add(Context.AbsoluteUri, ClaimsProviderName, ClaimsProviderName, 1033, "STS#0", FarmAdmin, String.Empty, String.Empty);
+                spSite.RootWeb.CreateDefaultAssociatedGroups(FarmAdmin, FarmAdmin, spSite.RootWeb.Title);
+
+                SPGroup membersGroup = spSite.RootWeb.AssociatedMemberGroup;
+                membersGroup.AddUser(userInfo.LoginName, userInfo.Email, userInfo.Name, userInfo.Notes);
+                spSite.Dispose();
+            }
+            else
+            {
+                using (SPSite spSite = new SPSite(Context.AbsoluteUri))
+                {
+                    SPGroup membersGroup = spSite.RootWeb.AssociatedMemberGroup;
+                    membersGroup.AddUser(userInfo.LoginName, userInfo.Email, userInfo.Name, userInfo.Notes);
+                }
+            }
+        }
+        else
+        {
+            Console.WriteLine($"Web app {Context} was NOT found.");
+        }
+    }
+
+    public static SPProviderHierarchyTree[] DoSearchOperation(string inputValue)
+    {
+        SPClaimProviderOperationOptions mode = SPClaimProviderOperationOptions.DisableHierarchyAugmentation;
+        string[] providerNames = new string[] { "AllUsers", "LDAPCP", "AzureCP", "AD" };
+        string[] entityTypes = new string[] { "User", "SecGroup", "SharePointGroup", "System", "FormsRole" };
+
+        SPProviderHierarchyTree[] providerResults = SPClaimProviderOperations.Search(UnitTestsHelper.Context, mode, providerNames, entityTypes, inputValue, 30);
+        return providerResults;
+    }
+
+    public static PickerEntity[] DoValidationOperation(SPClaim inputClaim)
+    {
+        SPClaimProviderOperationOptions mode = SPClaimProviderOperationOptions.AllZones | SPClaimProviderOperationOptions.OverrideVisibleConfiguration;
+        string[] providerNames = null;
+        string[] entityTypes = new string[] { "User" };
+
+        PickerEntity[] entities = SPClaimProviderOperations.Resolve(UnitTestsHelper.Context, mode, providerNames, entityTypes, inputClaim);
+        return entities;
+    }
+
+    public static void DoAugmentationOperationAndVerifyResult(string claimType, string claimValue, bool shouldHavePermissions)
+    {
+        SPClaim inputClaim = new SPClaim(claimType, claimValue, ClaimValueTypes.String, SPOriginalIssuers.Format(SPOriginalIssuerType.TrustedProvider, UnitTestsHelper.SPTrust.Name));
+
+        using (SPSite site = new SPSite(UnitTestsHelper.Context.AbsoluteUri))
+        {
+            // SPSite.RootWeb should not be disposed: https://blogs.msdn.microsoft.com/rogerla/2008/10/04/updated-spsite-rootweb-dispose-guidance/
+            SPWeb rootWeb = site.RootWeb;
+            bool entityHasPerms = rootWeb.DoesUserHavePermissions(inputClaim.ToEncodedString(), TrustedGroupToAdd_PermissionsAssigned);
+            if (shouldHavePermissions) Assert.IsTrue(entityHasPerms);
+        }
+    }
+
+    public static void VerifySearchResult(SPProviderHierarchyTree[] providerResults, int expectedCount, string expectedClaimValue)
+    {
+        foreach (SPProviderHierarchyTree providerResult in providerResults)
+        {
+            if (providerResult.ProviderName == UnitTestsHelper.ClaimsProviderName)
+            {
+                Assert.AreEqual(expectedCount, providerResult.Count);
+
+                if (expectedCount == 0)
+                {
+                    return;
+                }
+                else if (expectedCount == 1)
+                {
+                    PickerEntity entity = providerResult.Children[0].EntityData[0];
+                    StringAssert.AreEqualIgnoringCase(expectedClaimValue, entity.Claim.Value);
+                    return;
+                }
+                else
+                {
+                    foreach (var children in providerResult.Children)
+                    {
+                        foreach (var entity in children.EntityData)
+                        {
+                            if (String.Equals(expectedClaimValue, entity.Claim.Value))
+                            {
+                                StringAssert.AreEqualIgnoringCase(expectedClaimValue, entity.Claim.Value);
+                                return;
+                            }
+                        }
+                    }
+                    Assert.Fail($"No entity with claim value {expectedClaimValue} was found in the entities returned by {UnitTestsHelper.ClaimsProviderName}");
+                }
+            }
+        }
+        Assert.AreEqual(expectedCount, 0);
+    }
+
+    public static void VerifyValidationResult(PickerEntity[] entities, bool shouldValidate, string expectedClaimValue)
+    {
+        int expectedCount = shouldValidate ? 1 : 0;
+        Assert.AreEqual(expectedCount, entities.Length);
+        if (shouldValidate) StringAssert.AreEqualIgnoringCase(expectedClaimValue, entities[0].Claim.Value);
+    }
+}
+
+public class SearchEntityDataSourceCollection : IEnumerable
+{
+    public IEnumerator GetEnumerator()
+    {
+        yield return new[] { "AADGroup1", "1", "5b0f6c56-c87f-44c3-9354-56cba03da433" };
+        yield return new[] { "AADGroupTes", "1", "99abdc91-e6e0-475c-a0ba-5014f91de853" };
+    }
+}
+
+public class SearchEntityDataSource
+{
+    public static IEnumerable<TestCaseData> GetTestData()
+    {
+        DataTable dt = DataTable.New.ReadCsv(UnitTestsHelper.DataFile_SearchTests);
+
+        foreach (Row row in dt.Rows)
+        {
+            var registrationData = new SearchEntityData();
+            registrationData.Input = row["Input"];
+            registrationData.ExpectedResultCount = Convert.ToInt32(row["ExpectedResultCount"]);
+            registrationData.ExpectedEntityClaimValue = row["ExpectedEntityClaimValue"];
+            yield return new TestCaseData(new object[] { registrationData });
+        }
+    }
+
+    //public class ReadCSV
+    //{
+    //    public void GetValue()
+    //    {
+    //        TextReader tr1 = new StreamReader(@"c:\pathtofile\filename", true);
+
+    //        var Data = tr1.ReadToEnd().Split('\n')
+    //        .Where(l => l.Length > 0)  //nonempty strings
+    //        .Skip(1)               // skip header 
+    //        .Select(s => s.Trim())   // delete whitespace
+    //        .Select(l => l.Split(',')) // get arrays of values
+    //        .Select(l => new { Field1 = l[0], Field2 = l[1], Field3 = l[2] });
+    //    }
+    //}
+}
+
+public class SearchEntityData
+{
+    public string Input;
+    public int ExpectedResultCount;
+    public string ExpectedEntityClaimValue;
+}
+
+public class ValidateEntityDataSource
+{
+    public static IEnumerable<TestCaseData> GetTestData()
+    {
+        DataTable dt = DataTable.New.ReadCsv(UnitTestsHelper.DataFile_ValidationTests);
+        foreach (Row row in dt.Rows)
+        {
+            var registrationData = new ValidateEntityData();
+            registrationData.ClaimValue = row["ClaimValue"];
+            registrationData.ShouldValidate = Convert.ToBoolean(row["ShouldValidate"]);
+            registrationData.IsMemberOfTrustedGroup = Convert.ToBoolean(row["IsMemberOfTrustedGroup"]);
+            yield return new TestCaseData(new object[] { registrationData });
+        }
+    }
+}
+
+public class ValidateEntityData
+{
+    public string ClaimValue;
+    public bool ShouldValidate;
+    public bool IsMemberOfTrustedGroup;
+}

--- a/AzureCP.Tests/app.config
+++ b/AzureCP.Tests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <!--<dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+      </dependentAssembly>-->
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/AzureCP.Tests/packages.config
+++ b/AzureCP.Tests/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="CsvTools" version="1.0.12" targetFramework="net461" />
+  <package id="NUnit" version="3.10.1" targetFramework="net461" />
+  <package id="NUnit3TestAdapter" version="3.10.0" targetFramework="net461" />
+</packages>

--- a/AzureCP.sln
+++ b/AzureCP.sln
@@ -5,6 +5,11 @@ VisualStudioVersion = 15.0.27130.2020
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzureCP", "AzureCP\AzureCP.csproj", "{EEC47949-34B5-4805-A04D-A372BE75D3CB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzureCP.Tests", "AzureCP.Tests\AzureCP.Tests.csproj", "{DB8C79E5-F7F7-4841-8A8C-A9832A9CAE88}"
+	ProjectSection(ProjectDependencies) = postProject
+		{EEC47949-34B5-4805-A04D-A372BE75D3CB} = {EEC47949-34B5-4805-A04D-A372BE75D3CB}
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -22,6 +27,14 @@ Global
 		{EEC47949-34B5-4805-A04D-A372BE75D3CB}.Release|Any CPU.Deploy.0 = Release|Any CPU
 		{EEC47949-34B5-4805-A04D-A372BE75D3CB}.Release|x64.ActiveCfg = Release|Any CPU
 		{EEC47949-34B5-4805-A04D-A372BE75D3CB}.Release|x64.Build.0 = Release|Any CPU
+		{DB8C79E5-F7F7-4841-8A8C-A9832A9CAE88}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DB8C79E5-F7F7-4841-8A8C-A9832A9CAE88}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DB8C79E5-F7F7-4841-8A8C-A9832A9CAE88}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DB8C79E5-F7F7-4841-8A8C-A9832A9CAE88}.Debug|x64.Build.0 = Debug|Any CPU
+		{DB8C79E5-F7F7-4841-8A8C-A9832A9CAE88}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DB8C79E5-F7F7-4841-8A8C-A9832A9CAE88}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DB8C79E5-F7F7-4841-8A8C-A9832A9CAE88}.Release|x64.ActiveCfg = Release|Any CPU
+		{DB8C79E5-F7F7-4841-8A8C-A9832A9CAE88}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/AzureCP/AzureCP.cs
+++ b/AzureCP/AzureCP.cs
@@ -216,7 +216,6 @@ namespace azurecp
                     {
                         // Identity claim type found, set IdentityClaimTypeConfig property
                         identityClaimTypeFound = true;
-                        //IdentityClaimTypeConfig = claimTypeConfig as IdentityClaimTypeConfig;
                         IdentityClaimTypeConfig = IdentityClaimTypeConfig.ConvertClaimTypeConfig(claimTypeConfig);
                     }
                     else if (!groupClaimTypeFound && claimTypeConfig.EntityType == DirectoryObjectType.Group)

--- a/AzureCP/AzureCP.cs
+++ b/AzureCP/AzureCP.cs
@@ -1182,7 +1182,7 @@ namespace azurecp
                     timer.Stop();
                 }
                 if (tenantResult != null)
-                    ClaimsProviderLogging.Log($"[{ProviderInternalName}] Got {tenantResult.UsersAndGroups.Count().ToString()} users/groups and {tenantResult.DomainsRegisteredInAzureADTenant.Count().ToString()} registered domains in {timer.ElapsedMilliseconds.ToString()} ms from '{tenant.TenantName}' with input '{currentContext.Input}'", TraceSeverity.Medium, EventSeverity.Information, TraceCategory.Lookup);
+                    ClaimsProviderLogging.Log($"[{ProviderInternalName}] Got {tenantResult.UsersAndGroups.Count().ToString()} users/groups in {timer.ElapsedMilliseconds.ToString()} ms from '{tenant.TenantName}' with input '{currentContext.Input}'", TraceSeverity.Medium, EventSeverity.Information, TraceCategory.Lookup);
                 else
                     ClaimsProviderLogging.Log($"[{ProviderInternalName}] Got no result from '{tenant.TenantName}' with input '{currentContext.Input}', search took {timer.ElapsedMilliseconds.ToString()} ms", TraceSeverity.Medium, EventSeverity.Information, TraceCategory.Lookup);
                 return tenantResult;
@@ -1304,12 +1304,12 @@ namespace azurecp
         {
             // Split results between users/groups and list of registered domains in the tenant
             List<DirectoryObject> usersAndGroups = new List<DirectoryObject>();
-            List<string> domains = new List<string>();
+            //List<string> domains = new List<string>();
             // For each Azure AD tenant
             foreach (AzureADResult tenantResults in azureADResults)
             {
                 usersAndGroups.AddRange(tenantResults.UsersAndGroups);
-                domains.AddRange(tenantResults.DomainsRegisteredInAzureADTenant);
+                //domains.AddRange(tenantResults.DomainsRegisteredInAzureADTenant);
             }
 
             // Return if no user / groups is found, or if no registered domain is found

--- a/AzureCP/AzureCP.cs
+++ b/AzureCP/AzureCP.cs
@@ -664,6 +664,7 @@ namespace azurecp
             List<SPClaim> groups = new List<SPClaim>();
 
             // Create a task for each tenant to query
+            // Using list CurrentConfiguration.AzureTenants directly doesn't cause thread safety issues because no property from this list is written during augmentation
             var tenantQueryTasks = this.CurrentConfiguration.AzureTenants.Select(async tenant =>
             {
                 return await GetGroupMembershipFromAzureADAsync(currentContext, groupClaimTypeSettings, tenant).ConfigureAwait(false);
@@ -1002,9 +1003,7 @@ namespace azurecp
             string userSelect = String.Empty;
             string groupSelect = String.Empty;
 
-            // BUG: FILTERS MUST BE SET IN AN OBJECT CREATED IN THIS METHOD (TO BE BOUND TO CURRENT THREAD), OTHERWISE FILTER MAY BE UPDATED BY MULTIPLE THREADS
-            // Somehow, this constructor is not working, AzureTenant must be explicitely copied into new list
-            //List<AzureTenant> azureTenants = new List<AzureTenant>(this.CurrentConfiguration.AzureTenants);
+            // BUG: Filters must be set in an object created in this method (to be bound to current thread), otherwise filter may be updated by multiple threads
             List<AzureTenant> azureTenants = new List<AzureTenant>(this.CurrentConfiguration.AzureTenants.Count);
             foreach (AzureTenant tenant in this.CurrentConfiguration.AzureTenants)
             {

--- a/AzureCP/AzureCP.cs
+++ b/AzureCP/AzureCP.cs
@@ -93,10 +93,11 @@ namespace azurecp
                     globalConfiguration = GetConfiguration(context, entityTypes, PersistedObjectName);
                     if (globalConfiguration == null)
                     {
-                        ClaimsProviderLogging.Log($"[{ProviderInternalName}] Configuration '{PersistedObjectName}' was not found. Visit AzureCP admin pages in central administration to create it.",
+                        ClaimsProviderLogging.Log($"[{ProviderInternalName}] Configuration '{PersistedObjectName}' was not found in configuration database, use default configuration instead. Visit AzureCP admin pages in central administration to create it.",
                             TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.Core);
                         // Cannot continue
-                        success = false;
+                        globalConfiguration = AzureCPConfig.ReturnDefaultConfiguration(SPTrust.Name);
+                        refreshConfig = true;
                     }
                     else
                     {
@@ -106,14 +107,6 @@ namespace azurecp
                     if (globalConfiguration.ClaimTypes == null || globalConfiguration.ClaimTypes.Count == 0)
                     {
                         ClaimsProviderLogging.Log($"[{ProviderInternalName}] Configuration '{PersistedObjectName}' was found but collection ClaimTypes is null or empty. Visit AzureCP admin pages in central administration to create it.",
-                            TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.Core);
-                        // Cannot continue 
-                        success = false;
-                    }
-
-                    if (globalConfiguration.AzureTenants == null || globalConfiguration.AzureTenants.Count == 0)
-                    {
-                        ClaimsProviderLogging.Log($"[{ProviderInternalName}] Configuration '{PersistedObjectName}' was found but there is no Azure AD tenant registered. Visit AzureCP admin pages in central administration to register one.",
                             TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.Core);
                         // Cannot continue 
                         success = false;
@@ -164,14 +157,13 @@ namespace azurecp
                     SetCustomConfiguration(context, entityTypes);
                     if (this.CurrentConfiguration.ClaimTypes == null)
                     {
-                        // this.CurrentConfiguration.ClaimTypes was set to null in SetCustomConfiguration, which is bad
-                        ClaimsProviderLogging.Log(String.Format("[{0}] ClaimTypes was set to null in SetCustomConfiguration, don't set it or set it with actual entries.", ProviderInternalName), TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.Core);
+                        ClaimsProviderLogging.Log($"[{ProviderInternalName}] List if claim types was set to null in method SetCustomConfiguration for configuration '{PersistedObjectName}'.", TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.Core);
                         return false;
                     }
 
                     if (this.CurrentConfiguration.AzureTenants == null || this.CurrentConfiguration.AzureTenants.Count == 0)
                     {
-                        ClaimsProviderLogging.Log(String.Format("[{0}] AzureTenants was not set. Override method SetCustomConfiguration to set it.", ProviderInternalName), TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.Core);
+                        ClaimsProviderLogging.Log($"[{ProviderInternalName}] There is no Azure tenant registered in the configuration '{PersistedObjectName}'. Visit AzureCP in central administration to add it, or override method SetCustomConfiguration.", TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.Core);
                         return false;
                     }
 

--- a/AzureCP/AzureCP.cs
+++ b/AzureCP/AzureCP.cs
@@ -247,6 +247,7 @@ namespace azurecp
                         if (MainGroupClaimTypeConfig == null) continue;
                         claimTypeConfig.ClaimType = MainGroupClaimTypeConfig.ClaimType;
                         claimTypeConfig.DirectoryObjectPropertyToShowAsDisplayText = MainGroupClaimTypeConfig.DirectoryObjectPropertyToShowAsDisplayText;
+                        claimTypeConfig.ClaimTypeDisplayName = MainGroupClaimTypeConfig.ClaimTypeDisplayName;
                     }
                     additionalClaimTypeConfigList.Add(claimTypeConfig);
                 }
@@ -461,15 +462,15 @@ namespace azurecp
         /// Override this method to customize display text of permission created
         /// </summary>
         /// <param name="entity"></param>
-        /// <param name="isIdentityClaimType"></param>
+        /// <param name="isMappedClaimTypeConfig"></param>
         /// <param name="result"></param>
         /// <returns></returns>
-        protected virtual string FormatPermissionDisplayText(PickerEntity entity, bool isIdentityClaimType, AzureCPResult result)
+        protected virtual string FormatPermissionDisplayText(PickerEntity entity, bool isMappedClaimTypeConfig, AzureCPResult result)
         {
             string entityDisplayText = this.CurrentConfiguration.EntityDisplayTextPrefix;
             if (result.ClaimTypeConfig.DirectoryObjectPropertyToShowAsDisplayText != AzureADObjectProperty.NotSet)
             {
-                if (!isIdentityClaimType) entityDisplayText += "(" + result.ClaimTypeConfig.ClaimTypeDisplayName + ") ";
+                if (!isMappedClaimTypeConfig || result.ClaimTypeConfig.EntityType == DirectoryObjectType.Group) entityDisplayText += "(" + result.ClaimTypeConfig.ClaimTypeDisplayName + ") ";
 
                 string graphPropertyToDisplayValue = GetPropertyValue(result.UserOrGroupResult, result.ClaimTypeConfig.DirectoryObjectPropertyToShowAsDisplayText.ToString());
                 if (!String.IsNullOrEmpty(graphPropertyToDisplayValue)) entityDisplayText += graphPropertyToDisplayValue;
@@ -477,7 +478,7 @@ namespace azurecp
             }
             else
             {
-                if (isIdentityClaimType)
+                if (isMappedClaimTypeConfig)
                 {
                     entityDisplayText += result.QueryMatchValue;
                 }

--- a/AzureCP/AzureCP.cs
+++ b/AzureCP/AzureCP.cs
@@ -224,7 +224,8 @@ namespace azurecp
                     {
                         // Identity claim type found, set IdentityClaimTypeConfig property
                         identityClaimTypeFound = true;
-                        IdentityClaimTypeConfig = claimTypeConfig as IdentityClaimTypeConfig;
+                        //IdentityClaimTypeConfig = claimTypeConfig as IdentityClaimTypeConfig;
+                        IdentityClaimTypeConfig = IdentityClaimTypeConfig.ConvertClaimTypeConfig(claimTypeConfig);
                     }
                     else if (!groupClaimTypeFound && claimTypeConfig.EntityType == DirectoryObjectType.Group)
                     {

--- a/AzureCP/AzureCP.cs
+++ b/AzureCP/AzureCP.cs
@@ -32,7 +32,7 @@ namespace azurecp
     {
         public const string _ProviderInternalName = "AzureCP";
         public virtual string ProviderInternalName => "AzureCP";
-        public virtual string PersistedObjectName => ClaimsProviderConstants.AZURECPCONFIG_NAME;
+        public virtual string PersistedObjectName => ClaimsProviderConstants.CONFIG_NAME;
 
         private object Lock_Init = new object();
         private ReaderWriterLockSlim Lock_Config = new ReaderWriterLockSlim();

--- a/AzureCP/AzureCP.cs
+++ b/AzureCP/AzureCP.cs
@@ -694,7 +694,7 @@ namespace azurecp
             if (user == null)
             {
                 // If user was not found, he might be a Guest user. Query to check this: /users?$filter=userType eq 'Guest' and mail eq 'guest@live.com'&$select=userPrincipalName, Id
-                string guestFilter = HttpUtility.UrlEncode($"userType eq 'Guest' and mail eq '{currentContext.IncomingEntity.Value}'");
+                string guestFilter = HttpUtility.UrlEncode($"userType eq 'Guest' and {IdentityClaimTypeConfig.DirectoryObjectPropertyForGuestUsers} eq '{currentContext.IncomingEntity.Value}'");
                 userResult = await tenant.GraphService.Users.Request().Filter(guestFilter).Select(HttpUtility.UrlEncode("userPrincipalName, Id")).GetAsync().ConfigureAwait(false);
                 user = userResult.FirstOrDefault();
                 if (user == null) return claims;
@@ -704,6 +704,7 @@ namespace azurecp
             {
                 // POST to /v1.0/users/user@TENANT.onmicrosoft.com/microsoft.graph.getMemberGroups is the preferred way to return security groups as it includes nested groups
                 // But it returns only the group IDs so it can be used only if groupClaimTypeConfig.DirectoryObjectProperty == AzureADObjectProperty.Id
+                // For Guest users, it must be the id: POST to /v1.0/users/18ff6ae9-dd01-4008-a786-aabf71f1492a/microsoft.graph.getMemberGroups
                 IDirectoryObjectGetMemberGroupsCollectionPage groupIDs = await tenant.GraphService.Users[user.Id].GetMemberGroups(true).Request().PostAsync().ConfigureAwait(false);
                 bool morePages = groupIDs?.Count > 0;
                 while (morePages)

--- a/AzureCP/AzureCP.cs
+++ b/AzureCP/AzureCP.cs
@@ -100,7 +100,7 @@ namespace azurecp
                     }
                     else
                     {
-                        ((AzureCPConfig)globalConfiguration).CheckAndCleanPersistedObject();
+                        ((AzureCPConfig)globalConfiguration).CheckAndCleanConfiguration(SPTrust.Name);
                     }
 
                     if (globalConfiguration.ClaimTypes == null || globalConfiguration.ClaimTypes.Count == 0)
@@ -1314,6 +1314,10 @@ namespace azurecp
                                 TraceSeverity.Verbose, EventSeverity.Verbose, TraceCategory.Lookup);
                             continue;
                         }
+
+                        //// Test to deal issue reported in https://github.com/MicrosoftDocs/OfficeDocs-Enterprise/issues/43
+                        //User user = userOrGroup as User;
+                        //user.UserPrincipalName = user.Mail;
                     }
                     currentObject = userOrGroup;
                     objectType = DirectoryObjectType.User;

--- a/AzureCP/AzureCP.cs
+++ b/AzureCP/AzureCP.cs
@@ -90,7 +90,7 @@ namespace azurecp
                     }
                     if (!CheckIfShouldProcessInput(context)) return false;
 
-                    globalConfiguration = GetConfiguration(context, entityTypes, PersistedObjectName);
+                    globalConfiguration = GetConfiguration(context, entityTypes, PersistedObjectName, SPTrust.Name);
                     if (globalConfiguration == null)
                     {
                         ClaimsProviderLogging.Log($"[{ProviderInternalName}] Configuration '{PersistedObjectName}' was not found in configuration database, use default configuration instead. Visit AzureCP admin pages in central administration to create it.",
@@ -274,9 +274,9 @@ namespace azurecp
         /// To use a custom persisted object, override property PersistedObjectName and set its name
         /// </summary>
         /// <returns></returns>
-        protected virtual IAzureCPConfiguration GetConfiguration(Uri context, string[] entityTypes, string persistedObjectName)
+        protected virtual IAzureCPConfiguration GetConfiguration(Uri context, string[] entityTypes, string persistedObjectName, string spTrustName)
         {
-            return AzureCPConfig.GetConfiguration(persistedObjectName);
+            return AzureCPConfig.GetConfiguration(persistedObjectName, spTrustName);
         }
 
         /// <summary>

--- a/AzureCP/AzureCP.cs
+++ b/AzureCP/AzureCP.cs
@@ -95,7 +95,7 @@ namespace azurecp
                     {
                         ClaimsProviderLogging.Log($"[{ProviderInternalName}] Configuration '{PersistedObjectName}' was not found in configuration database, use default configuration instead. Visit AzureCP admin pages in central administration to create it.",
                             TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.Core);
-                        // Cannot continue
+                        // Return default configuration and set refreshConfig to true to give a chance to deprecated method SetCustomConfiguration() to set AzureTenants list
                         globalConfiguration = AzureCPConfig.ReturnDefaultConfiguration(SPTrust.Name);
                         refreshConfig = true;
                     }
@@ -163,7 +163,7 @@ namespace azurecp
 
                     if (this.CurrentConfiguration.AzureTenants == null || this.CurrentConfiguration.AzureTenants.Count == 0)
                     {
-                        ClaimsProviderLogging.Log($"[{ProviderInternalName}] There is no Azure tenant registered in the configuration '{PersistedObjectName}'. Visit AzureCP in central administration to add it, or override method SetCustomConfiguration.", TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.Core);
+                        ClaimsProviderLogging.Log($"[{ProviderInternalName}] There is no Azure tenant registered in the configuration '{PersistedObjectName}'. Visit AzureCP in central administration to add it, or override method GetConfiguration.", TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.Core);
                         return false;
                     }
 

--- a/AzureCP/AzureCP.csproj
+++ b/AzureCP/AzureCP.csproj
@@ -52,17 +52,17 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Graph, Version=1.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Graph.1.9.0\lib\net45\Microsoft.Graph.dll</HintPath>
+    <Reference Include="Microsoft.Graph, Version=1.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Graph.1.10.0\lib\net45\Microsoft.Graph.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Graph.Core, Version=1.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Graph.Core.1.9.0\lib\net45\Microsoft.Graph.Core.dll</HintPath>
+    <Reference Include="Microsoft.Graph.Core, Version=1.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Graph.Core.1.10.0\lib\net45\Microsoft.Graph.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=3.19.4.11002, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.19.4\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=3.19.8.16603, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.19.8\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory.Platform, Version=3.19.4.11002, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.19.4\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory.Platform, Version=3.19.8.16603, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.19.8\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
@@ -77,8 +77,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Nito.AsyncEx, Version=4.0.1.0, Culture=neutral, PublicKeyToken=09d695329ca273b7, processorArchitecture=MSIL">
       <HintPath>..\packages\Nito.AsyncEx.StrongNamed.4.0.1\lib\net45\Nito.AsyncEx.dll</HintPath>

--- a/AzureCP/AzureCP.csproj
+++ b/AzureCP/AzureCP.csproj
@@ -147,7 +147,6 @@
     <None Include="Features\AzureCP_Administration\AzureCP_Administration.feature">
       <FeatureId>{b82964c9-f57c-4826-b1dd-f03f63c7f197}</FeatureId>
     </None>
-    <None Include="key.snk" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/AzureCP/AzureCPConfig.cs
+++ b/AzureCP/AzureCPConfig.cs
@@ -414,7 +414,8 @@ namespace azurecp
                 {
                     try
                     {
-                        SPContext.Current.Web.AllowUnsafeUpdates = true;
+                        // SPContext may be null if code does not run in a SharePoint process (e.g. in unit tests process)
+                        if (SPContext.Current != null) SPContext.Current.Web.AllowUnsafeUpdates = true;
                         this.Update();
                         ClaimsProviderLogging.Log($"Configuration '{this.Name}' was not compatible with current version of AzureCP and was updated in configuration database. Some settings were reset to their default configuration",
                             TraceSeverity.High, EventSeverity.Information, TraceCategory.Core);
@@ -427,7 +428,7 @@ namespace azurecp
                     }
                     finally
                     {
-                        SPContext.Current.Web.AllowUnsafeUpdates = false;
+                        if (SPContext.Current != null) SPContext.Current.Web.AllowUnsafeUpdates = false;
                     }
                 }
             }

--- a/AzureCP/AzureCPConfig.cs
+++ b/AzureCP/AzureCPConfig.cs
@@ -6,7 +6,9 @@ using Microsoft.SharePoint.WebControls;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using System.Web;
 using static azurecp.ClaimsProviderLogging;
 using WIF4_5 = System.Security.Claims;
@@ -40,6 +42,8 @@ namespace azurecp
         public const bool EnforceOnly1ClaimTypeForGroup = true;     // In AzureCP, only 1 claim type can be used to create group permissions
         public const string DefaultMainGroupClaimType = WIF4_5.ClaimTypes.Role;
         public const string PUBLICSITEURL = "https://yvand.github.io/AzureCP/";
+        public static string ClaimsProviderVersion = FileVersionInfo.GetVersionInfo(Assembly.GetAssembly(typeof(AzureCP)).Location).FileVersion;
+        
 
 #if DEBUG
         public const int DEFAULT_TIMEOUT = 10000;
@@ -52,8 +56,8 @@ namespace azurecp
     {
         public List<AzureTenant> AzureTenants
         {
-            get { return AzureTenantsPersisted; }
-            set { AzureTenantsPersisted = value; }
+            get => AzureTenantsPersisted;
+            set => AzureTenantsPersisted = value;
         }
         [Persisted]
         private List<AzureTenant> AzureTenantsPersisted;
@@ -84,24 +88,24 @@ namespace azurecp
 
         public bool AlwaysResolveUserInput
         {
-            get { return AlwaysResolveUserInputPersisted; }
-            set { AlwaysResolveUserInputPersisted = value; }
+            get => AlwaysResolveUserInputPersisted;
+            set => AlwaysResolveUserInputPersisted = value;
         }
         [Persisted]
         private bool AlwaysResolveUserInputPersisted;
 
         public bool FilterExactMatchOnly
         {
-            get { return FilterExactMatchOnlyPersisted; }
-            set { FilterExactMatchOnlyPersisted = value; }
+            get => FilterExactMatchOnlyPersisted;
+            set => FilterExactMatchOnlyPersisted = value;
         }
         [Persisted]
         private bool FilterExactMatchOnlyPersisted;
 
         public bool EnableAugmentation
         {
-            get { return AugmentAADRolesPersisted; }
-            set { AugmentAADRolesPersisted = value; }
+            get => AugmentAADRolesPersisted;
+            set => AugmentAADRolesPersisted = value;
         }
         [Persisted]
         private bool AugmentAADRolesPersisted = true;
@@ -145,6 +149,9 @@ namespace azurecp
                 return _SPTrust;
             }
         }
+
+        [Persisted]
+        private string ClaimsProviderVersion;
 
         public AzureCPConfig(string persistedObjectName, SPPersistedObject parent, string spTrustName) : base(persistedObjectName, parent)
         {
@@ -403,72 +410,91 @@ namespace azurecp
             if (!String.IsNullOrEmpty(spTrustName) && !String.Equals(this.SPTrustName, spTrustName, StringComparison.InvariantCultureIgnoreCase))
             {
                 this.SPTrustName = spTrustName;
-                ClaimsProviderLogging.Log($"Updated the SPTrustedLoginProvider name to '{this.SPTrustName}' in configuration '{base.DisplayName}'.",
+                ClaimsProviderLogging.Log($"Updated property SPTrustName to \"{this.SPTrustName}\" in configuration \"{base.DisplayName}\".",
                     TraceSeverity.Medium, EventSeverity.Information, TraceCategory.Core);
                 configUpdated = true;
             }
 
-            try
+            if (!String.Equals(this.ClaimsProviderVersion, ClaimsProviderConstants.ClaimsProviderVersion, StringComparison.InvariantCultureIgnoreCase))
             {
-                // If AzureCP was updated from a version < v12, this.ClaimTypes.Count will throw a NullReferenceException
-                int testClaimTypeCollection = this.ClaimTypes.Count;
-            }
-            catch (NullReferenceException ex)
-            {
-                this.ClaimTypes = ReturnDefaultClaimTypesConfig(this.SPTrustName);
+                // Detect if current assembly has a version different than AzureCPConfig.ClaimsProviderVersion. If so, config needs a sanity check
+                ClaimsProviderLogging.Log($"Updated property ClaimsProviderVersion from \"{this.ClaimsProviderVersion}\" to \"{ClaimsProviderConstants.ClaimsProviderVersion}\" in configuration \"{base.DisplayName}\".",
+                    TraceSeverity.Medium, EventSeverity.Information, TraceCategory.Core);
+                this.ClaimsProviderVersion = ClaimsProviderConstants.ClaimsProviderVersion;
                 configUpdated = true;
             }
-
-            if (!String.IsNullOrEmpty(this.SPTrustName))
+            else if (!String.IsNullOrEmpty(this.SPTrustName))
             {
                 // ClaimTypeConfigCollection.SPTrust is not persisted so it should always be set explicitely
+                // Done in "else if" to not set this.ClaimTypes.SPTrust if we are not sure that this.ClaimTypes is in a good state
                 this.ClaimTypes.SPTrust = this.SPTrust;
             }
 
-            // Starting with v13, identity claim type is automatically detected and added when list is reset to default (so it should always be present)
-            // And it has its own class IdentityClaimTypeConfig that must be present as is to work correctly with Guest accounts
-            // Since this is fixed by resetting claim type config list, this also addresses the duplicate DirectoryObjectProperty per EntityType constraint
-            if (this.SPTrust != null)
-            {
-                ClaimTypeConfig identityCTConfig = this.ClaimTypes.FirstOrDefault(x => String.Equals(x.ClaimType, SPTrust.IdentityClaimTypeInformation.MappedClaimType, StringComparison.InvariantCultureIgnoreCase));
-                if (identityCTConfig == null || !(identityCTConfig is IdentityClaimTypeConfig))
-                {
-                    this.ClaimTypes = ReturnDefaultClaimTypesConfig(this.SPTrustName);
-                    ClaimsProviderLogging.Log($"Claim types configuration list was reset because the identity claim type was either not found or not configured correctly",
-                       TraceSeverity.High, EventSeverity.Information, TraceCategory.Core);
-                    configUpdated = true;
-                }
-            }
-
-            //// Starting with v13, adding 2 times a ClaimTypeConfig with the same EntityType and same DirectoryObjectProperty throws an InvalidOperationException
-            //// But this was possible before, so list this.ClaimTypes must be checked to be sure we are not in this scenario, and cleaned if so
-            //foreach (DirectoryObjectType entityType in Enum.GetValues(typeof(DirectoryObjectType)))
-            //{
-            //    var duplicatedPropertiesList = this.ClaimTypes.Where(x => x.EntityType == entityType)   // Check 1 EntityType
-            //                                              .GroupBy(x => x.DirectoryObjectProperty)      // Group by DirectoryObjectProperty
-            //                                              .Select(x => new
-            //                                              {
-            //                                                  DirectoryObjectProperty = x.Key,
-            //                                                  ObjectCount = x.Count()                   // For each DirectoryObjectProperty, how many items found
-            //                                              })
-            //                                              .Where(x => x.ObjectCount > 1);               // Keep only DirectoryObjectProperty found more than 1 time (for a given EntityType)
-            //    foreach (var duplicatedProperty in duplicatedPropertiesList)
-            //    {
-            //        ClaimTypeConfig ctConfigToDelete = null;
-            //        if (SPTrust != null && entityType == DirectoryObjectType.User)
-            //            ctConfigToDelete = this.ClaimTypes.FirstOrDefault(x => x.DirectoryObjectProperty == duplicatedProperty.DirectoryObjectProperty && x.EntityType == entityType && !String.Equals(x.ClaimType, SPTrust.IdentityClaimTypeInformation.MappedClaimType, StringComparison.InvariantCultureIgnoreCase));
-            //        else
-            //            ctConfigToDelete = this.ClaimTypes.FirstOrDefault(x => x.DirectoryObjectProperty == duplicatedProperty.DirectoryObjectProperty && x.EntityType == entityType);
-
-            //        this.ClaimTypes.Remove(ctConfigToDelete);
-            //        configUpdated = true;
-            //        ClaimsProviderLogging.Log($"Removed claim type '{ctConfigToDelete.ClaimType}' from claim types configuration list because it duplicates property {ctConfigToDelete.DirectoryObjectProperty}",
-            //           TraceSeverity.High, EventSeverity.Information, TraceCategory.Core);
-            //    }
-            //}
-
+            // Either claims provider was associated to a new SPTrustedLoginProvider
+            // Or version of the current assembly changed (upgrade)
+            // So let's do a sanity check of the configuration
             if (configUpdated)
             {
+                try
+                {
+                    // If AzureCP was updated from a version < v12, this.ClaimTypes.Count will throw a NullReferenceException
+                    int testClaimTypeCollection = this.ClaimTypes.Count;
+                }
+                catch (NullReferenceException ex)
+                {
+                    this.ClaimTypes = ReturnDefaultClaimTypesConfig(this.SPTrustName);
+                    configUpdated = true;
+                }
+
+                if (!String.IsNullOrEmpty(this.SPTrustName))
+                {
+                    // ClaimTypeConfigCollection.SPTrust is not persisted so it should always be set explicitely
+                    this.ClaimTypes.SPTrust = this.SPTrust;
+                }
+
+
+                // Starting with v13, identity claim type is automatically detected and added when list is reset to default (so it should always be present)
+                // And it has its own class IdentityClaimTypeConfig that must be present as is to work correctly with Guest accounts
+                // Since this is fixed by resetting claim type config list, this also addresses the duplicate DirectoryObjectProperty per EntityType constraint
+                if (this.SPTrust != null)
+                {
+                    ClaimTypeConfig identityCTConfig = this.ClaimTypes.FirstOrDefault(x => String.Equals(x.ClaimType, SPTrust.IdentityClaimTypeInformation.MappedClaimType, StringComparison.InvariantCultureIgnoreCase));
+                    if (identityCTConfig == null || !(identityCTConfig is IdentityClaimTypeConfig))
+                    {
+                        this.ClaimTypes = ReturnDefaultClaimTypesConfig(this.SPTrustName);
+                        ClaimsProviderLogging.Log($"Claim types configuration list was reset because the identity claim type was either not found or not configured correctly",
+                           TraceSeverity.High, EventSeverity.Information, TraceCategory.Core);
+                        configUpdated = true;
+                    }
+                }
+
+                // Starting with v13, adding 2 times a ClaimTypeConfig with the same EntityType and same DirectoryObjectProperty throws an InvalidOperationException
+                // But this was possible before, so list this.ClaimTypes must be checked to be sure we are not in this scenario, and cleaned if so
+                foreach (DirectoryObjectType entityType in Enum.GetValues(typeof(DirectoryObjectType)))
+                {
+                    var duplicatedPropertiesList = this.ClaimTypes.Where(x => x.EntityType == entityType)   // Check 1 EntityType
+                                                              .GroupBy(x => x.DirectoryObjectProperty)      // Group by DirectoryObjectProperty
+                                                              .Select(x => new
+                                                              {
+                                                                  DirectoryObjectProperty = x.Key,
+                                                                  ObjectCount = x.Count()                   // For each DirectoryObjectProperty, how many items found
+                                                              })
+                                                              .Where(x => x.ObjectCount > 1);               // Keep only DirectoryObjectProperty found more than 1 time (for a given EntityType)
+                    foreach (var duplicatedProperty in duplicatedPropertiesList)
+                    {
+                        ClaimTypeConfig ctConfigToDelete = null;
+                        if (SPTrust != null && entityType == DirectoryObjectType.User)
+                            ctConfigToDelete = this.ClaimTypes.FirstOrDefault(x => x.DirectoryObjectProperty == duplicatedProperty.DirectoryObjectProperty && x.EntityType == entityType && !String.Equals(x.ClaimType, SPTrust.IdentityClaimTypeInformation.MappedClaimType, StringComparison.InvariantCultureIgnoreCase));
+                        else
+                            ctConfigToDelete = this.ClaimTypes.FirstOrDefault(x => x.DirectoryObjectProperty == duplicatedProperty.DirectoryObjectProperty && x.EntityType == entityType);
+
+                        this.ClaimTypes.Remove(ctConfigToDelete);
+                        configUpdated = true;
+                        ClaimsProviderLogging.Log($"Removed claim type '{ctConfigToDelete.ClaimType}' from claim types configuration list because it duplicates property {ctConfigToDelete.DirectoryObjectProperty}",
+                           TraceSeverity.High, EventSeverity.Information, TraceCategory.Core);
+                    }
+                }
+
                 if (Version > 0)
                 {
                     try
@@ -476,13 +502,13 @@ namespace azurecp
                         // SPContext may be null if code does not run in a SharePoint process (e.g. in unit tests process)
                         if (SPContext.Current != null) SPContext.Current.Web.AllowUnsafeUpdates = true;
                         this.Update();
-                        ClaimsProviderLogging.Log($"Configuration '{this.Name}' was not compatible with current version of AzureCP and was updated in configuration database. Some settings were updated or reset to their default configuration",
+                        ClaimsProviderLogging.Log($"Configuration '{this.Name}' was upgraded in configuration database and some settings were updated or reset to their default configuration",
                             TraceSeverity.High, EventSeverity.Information, TraceCategory.Core);
                     }
                     catch (Exception ex)
                     {
                         // It may fail if current user doesn't have permission to update the object in configuration database
-                        ClaimsProviderLogging.Log($"Configuration '{this.Name}' is not compatible with current version of AzureCP and was updated locally, but change could not be applied in configuration database. Please visit admin pages in central administration to fix configuration globally.",
+                        ClaimsProviderLogging.Log($"Configuration '{this.Name}' was upgraded locally, but changes could not be applied in configuration database. Please visit admin pages in central administration to upgrade configuration globally.",
                             TraceSeverity.High, EventSeverity.Information, TraceCategory.Core);
                     }
                     finally

--- a/AzureCP/AzureCPConfig.cs
+++ b/AzureCP/AzureCPConfig.cs
@@ -177,8 +177,11 @@ namespace azurecp
             try
             {
                 AzureCPConfig persistedObject = parent.GetChild<AzureCPConfig>(persistedObjectName);
-                persistedObject.CheckAndCleanConfiguration(String.Empty);
-                return persistedObject;
+                if (persistedObject != null)
+                {
+                    persistedObject.CheckAndCleanConfiguration(String.Empty);
+                    return persistedObject;
+                }
             }
             catch (Exception ex)
             {
@@ -250,7 +253,8 @@ namespace azurecp
 
         public AzureCPConfig CopyPersistedProperties()
         {
-            AzureCPConfig copy = new AzureCPConfig(this.Name, this.Parent, this.SPTrustName);
+            AzureCPConfig copy = new AzureCPConfig();
+            copy.SPTrustName = this.SPTrustName;
             copy.AzureTenants = new List<AzureTenant>(this.AzureTenants);
             copy.ClaimTypes = new ClaimTypeConfigCollection();
             foreach (ClaimTypeConfig currentObject in this.ClaimTypes)

--- a/AzureCP/AzureCPConfig.cs
+++ b/AzureCP/AzureCPConfig.cs
@@ -409,9 +409,9 @@ namespace azurecp
 
             if (!String.IsNullOrEmpty(spTrustName) && !String.Equals(this.SPTrustName, spTrustName, StringComparison.InvariantCultureIgnoreCase))
             {
-                this.SPTrustName = spTrustName;
-                ClaimsProviderLogging.Log($"Updated property SPTrustName to \"{this.SPTrustName}\" in configuration \"{base.DisplayName}\".",
+                ClaimsProviderLogging.Log($"Updated property SPTrustName from \"{this.SPTrustName}\" to \"{spTrustName}\" in configuration \"{base.DisplayName}\".",
                     TraceSeverity.Medium, EventSeverity.Information, TraceCategory.Core);
+                this.SPTrustName = spTrustName;
                 configUpdated = true;
             }
 

--- a/AzureCP/AzureCPConfig.cs
+++ b/AzureCP/AzureCPConfig.cs
@@ -74,7 +74,7 @@ namespace azurecp
             set
             {
                 _ClaimTypes = value;
-                _ClaimTypesCollection = value.innerCol;
+                _ClaimTypesCollection = value == null ? null : value.innerCol;
             }
         }
         [Persisted]
@@ -329,6 +329,12 @@ namespace azurecp
             if (String.IsNullOrWhiteSpace(spTrustName)) throw new ArgumentNullException("spTrustName cannot be null.");
 
             SPTrustedLoginProvider spTrust = SPSecurityTokenServiceManager.Local.TrustedLoginProviders.GetProviderByName(spTrustName);
+            if (spTrust == null)
+            {
+                ClaimsProviderLogging.Log($"SPTrustedLoginProvider '{spTrustName}' was not found ", TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.Core);
+                return null;
+            }
+
             return new ClaimTypeConfigCollection
             {
                 // Identity claim type. "Name" (http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name) is a reserved claim type in SharePoint that cannot be used in the SPTrust.

--- a/AzureCP/AzureCPConfig.cs
+++ b/AzureCP/AzureCPConfig.cs
@@ -29,8 +29,8 @@ namespace azurecp
 
     public class ClaimsProviderConstants
     {
-        public const string AZURECPCONFIG_ID = "0E9F8FB6-B314-4CCC-866D-DEC0BE76C237";
-        public const string AZURECPCONFIG_NAME = "AzureCPConfig";
+        public const string CONFIG_ID = "0E9F8FB6-B314-4CCC-866D-DEC0BE76C237";
+        public const string CONFIG_NAME = "AzureCPConfig";
         public const string GraphAPIResource = "https://graph.microsoft.com/";
         public const string AuthorityUriTemplate = "https://login.windows.net/{0}";
         public const string ResourceUrl = "https://graph.windows.net";
@@ -175,7 +175,7 @@ namespace azurecp
         /// <returns></returns>
         public static AzureCPConfig GetConfiguration()
         {
-            return GetConfiguration(ClaimsProviderConstants.AZURECPCONFIG_NAME, String.Empty);
+            return GetConfiguration(ClaimsProviderConstants.CONFIG_NAME, String.Empty);
         }
 
         /// <summary>

--- a/AzureCP/AzureCPConfig.cs
+++ b/AzureCP/AzureCPConfig.cs
@@ -196,6 +196,7 @@ namespace azurecp
             try
             {
                 ClaimTypeConfigCollection testUpdateCollection = new ClaimTypeConfigCollection();
+                testUpdateCollection.SPTrust = this.SPTrust;
                 foreach (ClaimTypeConfig curCTConfig in this.ClaimTypes)
                 {
                     testUpdateCollection.Add(curCTConfig, false);

--- a/AzureCP/AzureCPUserControl.cs
+++ b/AzureCP/AzureCPUserControl.cs
@@ -63,7 +63,7 @@ namespace azurecp.ControlTemplates
         }
 
         protected SPTrustedLoginProvider CurrentTrustedLoginProvider;
-        protected ClaimTypeConfig IdentityClaim;
+        protected IdentityClaimTypeConfig IdentityClaim;
         protected ConfigStatus Status;
 
         protected long PersistedObjectVersion
@@ -177,7 +177,7 @@ namespace azurecp.ControlTemplates
             PersistedObject.ClaimTypes.SPTrust = CurrentTrustedLoginProvider;
             if (IdentityClaim == null && Status == ConfigStatus.AllGood)
             {
-                IdentityClaim = this.IdentityClaim = PersistedObject.ClaimTypes.FirstOrDefault(x => String.Equals(CurrentTrustedLoginProvider.IdentityClaimTypeInformation.MappedClaimType, x.ClaimType, StringComparison.InvariantCultureIgnoreCase) && !x.UseMainClaimTypeOfDirectoryObject);
+                IdentityClaim = this.IdentityClaim = PersistedObject.ClaimTypes.FirstOrDefault(x => String.Equals(CurrentTrustedLoginProvider.IdentityClaimTypeInformation.MappedClaimType, x.ClaimType, StringComparison.InvariantCultureIgnoreCase) && !x.UseMainClaimTypeOfDirectoryObject) as IdentityClaimTypeConfig;
                 if (IdentityClaim == null) Status |= ConfigStatus.NoIdentityClaimType;
             }
             if (PersistedObjectVersion != PersistedObject.Version)

--- a/AzureCP/AzureCPUserControl.cs
+++ b/AzureCP/AzureCPUserControl.cs
@@ -158,10 +158,12 @@ namespace azurecp.ControlTemplates
                     return Status;
                 }
             }
+
             if (PersistedObject == null)
             {
                 Status |= ConfigStatus.PersistedObjectNotFound;
             }
+
             if (Status != ConfigStatus.AllGood)
             {
                 ClaimsProviderLogging.Log($"[{ClaimsProviderName}] {MostImportantError}", TraceSeverity.Unexpected, EventSeverity.Error, TraceCategory.Configuration);

--- a/AzureCP/AzureCPUserControl.cs
+++ b/AzureCP/AzureCPUserControl.cs
@@ -2,6 +2,7 @@
 using Microsoft.SharePoint;
 using Microsoft.SharePoint.Administration;
 using Microsoft.SharePoint.Administration.Claims;
+using Microsoft.SharePoint.Utilities;
 using Microsoft.SharePoint.WebControls;
 using System;
 using System.Linq;
@@ -83,7 +84,7 @@ namespace azurecp.ControlTemplates
                 if (Status == ConfigStatus.AllGood) return String.Empty;
 
                 if ((Status & ConfigStatus.NoSPTrustAssociation) == ConfigStatus.NoSPTrustAssociation)
-                    return String.Format(TextErrorNoSPTrustAssociation, ClaimsProviderName);
+                    return String.Format(TextErrorNoSPTrustAssociation, SPEncode.HtmlEncode(ClaimsProviderName));
 
                 if ((Status & ConfigStatus.PersistedObjectNotFound) == ConfigStatus.PersistedObjectNotFound)
                     return TextErrorPersistedObjectNotFound;

--- a/AzureCP/AzureCPUserControl.cs
+++ b/AzureCP/AzureCPUserControl.cs
@@ -48,7 +48,7 @@ namespace azurecp.ControlTemplates
                 {
                     if (_PersistedObject == null)
                     {
-                        _PersistedObject = AzureCPConfig.GetConfiguration(PersistedObjectName);
+                        _PersistedObject = AzureCPConfig.GetConfiguration(PersistedObjectName, this.CurrentTrustedLoginProvider.Name);
                     }
                     if (_PersistedObject == null)
                     {
@@ -172,7 +172,8 @@ namespace azurecp.ControlTemplates
                 return Status;
             }
 
-            PersistedObject.CheckAndCleanConfiguration(CurrentTrustedLoginProvider.Name);
+            // AzureCPConfig.GetConfiguration will call method AzureCPConfig.CheckAndCleanConfiguration();
+            //PersistedObject.CheckAndCleanConfiguration(CurrentTrustedLoginProvider.Name);
             PersistedObject.ClaimTypes.SPTrust = CurrentTrustedLoginProvider;
             if (IdentityClaim == null && Status == ConfigStatus.AllGood)
             {

--- a/AzureCP/AzureCPUserControl.cs
+++ b/AzureCP/AzureCPUserControl.cs
@@ -63,7 +63,7 @@ namespace azurecp.ControlTemplates
         }
 
         protected SPTrustedLoginProvider CurrentTrustedLoginProvider;
-        protected IdentityClaimTypeConfig IdentityClaim;
+        protected IdentityClaimTypeConfig IdentityCTConfig;
         protected ConfigStatus Status;
 
         protected long PersistedObjectVersion
@@ -175,10 +175,10 @@ namespace azurecp.ControlTemplates
             // AzureCPConfig.GetConfiguration will call method AzureCPConfig.CheckAndCleanConfiguration();
             //PersistedObject.CheckAndCleanConfiguration(CurrentTrustedLoginProvider.Name);
             PersistedObject.ClaimTypes.SPTrust = CurrentTrustedLoginProvider;
-            if (IdentityClaim == null && Status == ConfigStatus.AllGood)
+            if (IdentityCTConfig == null && Status == ConfigStatus.AllGood)
             {
-                IdentityClaim = this.IdentityClaim = PersistedObject.ClaimTypes.FirstOrDefault(x => String.Equals(CurrentTrustedLoginProvider.IdentityClaimTypeInformation.MappedClaimType, x.ClaimType, StringComparison.InvariantCultureIgnoreCase) && !x.UseMainClaimTypeOfDirectoryObject) as IdentityClaimTypeConfig;
-                if (IdentityClaim == null) Status |= ConfigStatus.NoIdentityClaimType;
+                IdentityCTConfig = this.IdentityCTConfig = PersistedObject.ClaimTypes.FirstOrDefault(x => String.Equals(CurrentTrustedLoginProvider.IdentityClaimTypeInformation.MappedClaimType, x.ClaimType, StringComparison.InvariantCultureIgnoreCase) && !x.UseMainClaimTypeOfDirectoryObject) as IdentityClaimTypeConfig;
+                if (IdentityCTConfig == null) Status |= ConfigStatus.NoIdentityClaimType;
             }
             if (PersistedObjectVersion != PersistedObject.Version)
             {

--- a/AzureCP/ClaimTypeConfig.cs
+++ b/AzureCP/ClaimTypeConfig.cs
@@ -300,6 +300,11 @@ namespace azurecp
                 throw new InvalidOperationException($"Prefix '{item.PrefixToBypassLookup}' is already set with another claim type and must be unique");
             }
 
+            if (Contains(item, new ClaimTypeConfigSameDirectoryConfiguration()))
+            {
+                throw new InvalidOperationException($"An item with property '{item.DirectoryObjectProperty}' already exists for the object type '{item.EntityType}'");
+            }
+
             if (Contains(item))
             {
                 if (String.IsNullOrEmpty(item.ClaimType))
@@ -670,6 +675,31 @@ namespace azurecp
         public override int GetHashCode(ClaimTypeConfig ct)
         {
             string hCode = ct.ClaimType + ct.EntityType + ct.UseMainClaimTypeOfDirectoryObject.ToString();
+            return hCode.GetHashCode();
+        }
+    }
+
+    /// <summary>
+    /// Check if a given object type (user or group) has 2 ClaimTypeConfig with the same LDAPAttribute and LDAPClass
+    /// </summary>
+    public class ClaimTypeConfigSameDirectoryConfiguration : EqualityComparer<ClaimTypeConfig>
+    {
+        public override bool Equals(ClaimTypeConfig existingCTConfig, ClaimTypeConfig newCTConfig)
+        {
+            if (existingCTConfig.DirectoryObjectProperty == newCTConfig.DirectoryObjectProperty &&
+                existingCTConfig.EntityType == newCTConfig.EntityType)
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public override int GetHashCode(ClaimTypeConfig ct)
+        {
+            string hCode = ct.DirectoryObjectProperty.ToString() + ct.EntityType;
             return hCode.GetHashCode();
         }
     }

--- a/AzureCP/ClaimTypeConfig.cs
+++ b/AzureCP/ClaimTypeConfig.cs
@@ -9,6 +9,17 @@ using WIF = System.Security.Claims;
 
 namespace azurecp
 {
+    public class IdentityClaimTypeConfig : ClaimTypeConfig
+    {
+        public AzureADObjectProperty DirectoryObjectPropertyForGuestUsers
+        {
+            get { return (AzureADObjectProperty)Enum.ToObject(typeof(AzureADObjectProperty), _DirectoryObjectPropertyForGuestUsers); }
+            set { _DirectoryObjectPropertyForGuestUsers = (int)value; }
+        }
+        [Persisted]
+        private int _DirectoryObjectPropertyForGuestUsers = (int)AzureADObjectProperty.Mail;
+    }
+
     /// <summary>
     /// Stores configuration associated to a claim type, and its mapping with the Azure AD attribute (GraphProperty)
     /// </summary>
@@ -218,6 +229,15 @@ namespace azurecp
         internal ClaimTypeConfigCollection(ref Collection<ClaimTypeConfig> innerCol)
         {
             this.innerCol = innerCol;
+        }
+
+        public bool InitializeIdentityClaimTypeConfig()
+        {
+            if (SPTrust == null) return false;
+
+            string identityClaimType = SPTrust.IdentityClaimTypeInformation.MappedClaimType;
+
+            return true;
         }
 
         public ClaimTypeConfig this[int index]

--- a/AzureCP/ClaimTypeConfig.cs
+++ b/AzureCP/ClaimTypeConfig.cs
@@ -18,6 +18,22 @@ namespace azurecp
         }
         [Persisted]
         private int _DirectoryObjectPropertyForGuestUsers = (int)AzureADObjectProperty.Mail;
+
+        public static IdentityClaimTypeConfig ConvertClaimTypeConfig(ClaimTypeConfig ctConfig)
+        {
+            IdentityClaimTypeConfig identityCTConfig = new IdentityClaimTypeConfig();
+            identityCTConfig.ClaimType = ctConfig.ClaimType;
+            identityCTConfig.ClaimTypeDisplayName = ctConfig.ClaimTypeDisplayName;
+            identityCTConfig.ClaimValueType = ctConfig.ClaimValueType;
+            identityCTConfig.DirectoryObjectProperty = ctConfig.DirectoryObjectProperty;
+            identityCTConfig.DirectoryObjectPropertyToShowAsDisplayText = ctConfig.DirectoryObjectPropertyToShowAsDisplayText;
+            identityCTConfig.EntityDataKey = ctConfig.EntityDataKey;
+            identityCTConfig.EntityType = ctConfig.EntityType;
+            identityCTConfig.FilterExactMatchOnly = ctConfig.FilterExactMatchOnly;
+            identityCTConfig.PrefixToBypassLookup = ctConfig.PrefixToBypassLookup;
+            identityCTConfig.UseMainClaimTypeOfDirectoryObject = ctConfig.UseMainClaimTypeOfDirectoryObject;
+            return identityCTConfig;
+        }
     }
 
     /// <summary>

--- a/AzureCP/ClaimTypeConfig.cs
+++ b/AzureCP/ClaimTypeConfig.cs
@@ -400,6 +400,31 @@ namespace azurecp
             innerCol.First(x => String.Equals(x.ClaimType, oldClaimType, StringComparison.InvariantCultureIgnoreCase)).SetFromObject(newItem);
         }
 
+        public void UpdateUserIdentifier(AzureADObjectProperty newIdentifier)
+        {
+            for (int i = 0; i < innerCol.Count; i++)
+            {
+                ClaimTypeConfig curCT = (ClaimTypeConfig)innerCol[i];
+                if (curCT.EntityType == DirectoryObjectType.User &&
+                    curCT.DirectoryObjectProperty == newIdentifier)
+                {
+                    innerCol.RemoveAt(i);
+                    break;
+                }
+            }
+
+            IdentityClaimTypeConfig identityClaimType = innerCol.FirstOrDefault(x  => x is IdentityClaimTypeConfig) as IdentityClaimTypeConfig;
+            if (identityClaimType == null) return;
+            identityClaimType.DirectoryObjectProperty = newIdentifier;
+        }
+
+        public void UpdateIdentifierForGuestUsers(AzureADObjectProperty newIdentifier)
+        {
+            IdentityClaimTypeConfig identityClaimType = innerCol.FirstOrDefault(x => x is IdentityClaimTypeConfig) as IdentityClaimTypeConfig;
+            if (identityClaimType == null) return;
+            identityClaimType.DirectoryObjectPropertyForGuestUsers = newIdentifier;
+        }
+
         public void Clear()
         {
             innerCol.Clear();

--- a/AzureCP/Features/AzureCP/AzureCP.EventReceiver.cs
+++ b/AzureCP/Features/AzureCP/AzureCP.EventReceiver.cs
@@ -59,6 +59,10 @@ namespace azurecp
 
         public override void FeatureUpgrading(SPFeatureReceiverProperties properties, string upgradeActionName, IDictionary<string, string> parameters)
         {
+            // Upgrade must be explicitely triggered as documented in https://www.sharepointnutsandbolts.com/2010/06/feature-upgrade-part-1-fundamentals.html
+            // In PowerShell: 
+            // $feature = [Microsoft.SharePoint.Administration.SPWebService]::AdministrationService.Features["d1817470-ca9f-4b0c-83c5-ea61f9b0660d"]
+            // $feature.Upgrade($false)
             SPSecurity.RunWithElevatedPrivileges(delegate ()
             {
                 ClaimsProviderLogging svc = ClaimsProviderLogging.Local;

--- a/AzureCP/Features/AzureCP/AzureCP.EventReceiver.cs
+++ b/AzureCP/Features/AzureCP/AzureCP.EventReceiver.cs
@@ -62,11 +62,14 @@ namespace azurecp
             SPSecurity.RunWithElevatedPrivileges(delegate ()
             {
                 ClaimsProviderLogging svc = ClaimsProviderLogging.Local;
-                AzureCPConfig config = AzureCPConfig.GetConfiguration(ClaimsProviderConstants.AZURECPCONFIG_NAME);
-                if (config != null)
-                {
-                    config.CheckAndCleanConfiguration(String.Empty);
-                }
+                var spTrust = AzureCP.GetSPTrustAssociatedWithCP(AzureCP._ProviderInternalName);
+                string spTrustName = spTrust == null ? String.Empty : spTrust.Name;
+                // AzureCPConfig.GetConfiguration will call method AzureCPConfig.CheckAndCleanConfiguration();
+                AzureCPConfig config = AzureCPConfig.GetConfiguration(ClaimsProviderConstants.AZURECPCONFIG_NAME, spTrustName);
+                //if (config != null)
+                //{
+                //    config.CheckAndCleanConfiguration(spTrustName);
+                //}
             });
         }
     }

--- a/AzureCP/Features/AzureCP/AzureCP.EventReceiver.cs
+++ b/AzureCP/Features/AzureCP/AzureCP.EventReceiver.cs
@@ -57,24 +57,18 @@ namespace azurecp
             });
         }
 
-        public override void FeatureUpgrading(SPFeatureReceiverProperties properties, string upgradeActionName, IDictionary<string, string> parameters)
-        {
-            // Upgrade must be explicitely triggered as documented in https://www.sharepointnutsandbolts.com/2010/06/feature-upgrade-part-1-fundamentals.html
-            // In PowerShell: 
-            // $feature = [Microsoft.SharePoint.Administration.SPWebService]::AdministrationService.Features["d1817470-ca9f-4b0c-83c5-ea61f9b0660d"]
-            // $feature.Upgrade($false)
-            SPSecurity.RunWithElevatedPrivileges(delegate ()
-            {
-                ClaimsProviderLogging svc = ClaimsProviderLogging.Local;
-                var spTrust = AzureCP.GetSPTrustAssociatedWithCP(AzureCP._ProviderInternalName);
-                string spTrustName = spTrust == null ? String.Empty : spTrust.Name;
-                // AzureCPConfig.GetConfiguration will call method AzureCPConfig.CheckAndCleanConfiguration();
-                AzureCPConfig config = AzureCPConfig.GetConfiguration(ClaimsProviderConstants.AZURECPCONFIG_NAME, spTrustName);
-                //if (config != null)
-                //{
-                //    config.CheckAndCleanConfiguration(spTrustName);
-                //}
-            });
-        }
+        /// <summary>
+        /// Upgrade must be explicitely triggered as documented in https://www.sharepointnutsandbolts.com/2010/06/feature-upgrade-part-1-fundamentals.html
+        /// In PowerShell: 
+        /// $feature = [Microsoft.SharePoint.Administration.SPWebService]::AdministrationService.Features["d1817470-ca9f-4b0c-83c5-ea61f9b0660d"]
+        /// $feature.Upgrade($false)
+        /// Since it's not automatic, this mechanism won't be used at all
+        /// </summary>
+        /// <param name="properties"></param>
+        /// <param name="upgradeActionName"></param>
+        /// <param name="parameters"></param>
+        //public override void FeatureUpgrading(SPFeatureReceiverProperties properties, string upgradeActionName, IDictionary<string, string> parameters)
+        //{
+        //}
     }
 }

--- a/AzureCP/Features/AzureCP/AzureCP.EventReceiver.cs
+++ b/AzureCP/Features/AzureCP/AzureCP.EventReceiver.cs
@@ -65,7 +65,7 @@ namespace azurecp
                 AzureCPConfig config = AzureCPConfig.GetConfiguration(ClaimsProviderConstants.AZURECPCONFIG_NAME);
                 if (config != null)
                 {
-                    config.CheckAndCleanPersistedObject();
+                    config.CheckAndCleanConfiguration(String.Empty);
                 }
             });
         }

--- a/AzureCP/Features/AzureCP/AzureCP.EventReceiver.cs
+++ b/AzureCP/Features/AzureCP/AzureCP.EventReceiver.cs
@@ -43,11 +43,11 @@ namespace azurecp
                     var spTrust = AzureCP.GetSPTrustAssociatedWithCP(AzureCP._ProviderInternalName);
                     if (spTrust != null)
                     {
-                        AzureCPConfig existingConfig = AzureCPConfig.GetConfiguration(ClaimsProviderConstants.AZURECPCONFIG_NAME);
+                        AzureCPConfig existingConfig = AzureCPConfig.GetConfiguration(ClaimsProviderConstants.CONFIG_NAME);
                         if (existingConfig == null)
-                            AzureCPConfig.CreateConfiguration(ClaimsProviderConstants.AZURECPCONFIG_ID, ClaimsProviderConstants.AZURECPCONFIG_NAME, spTrust.Name);
+                            AzureCPConfig.CreateConfiguration(ClaimsProviderConstants.CONFIG_ID, ClaimsProviderConstants.CONFIG_NAME, spTrust.Name);
                         else
-                            ClaimsProviderLogging.Log($"[{AzureCP._ProviderInternalName}] Use configuration \"{ClaimsProviderConstants.AZURECPCONFIG_NAME}\" found in the configuration database", TraceSeverity.High, EventSeverity.Information, ClaimsProviderLogging.TraceCategory.Configuration);
+                            ClaimsProviderLogging.Log($"[{AzureCP._ProviderInternalName}] Use configuration \"{ClaimsProviderConstants.CONFIG_NAME}\" found in the configuration database", TraceSeverity.High, EventSeverity.Information, ClaimsProviderLogging.TraceCategory.Configuration);
                     }
                 }
                 catch (Exception ex)
@@ -64,7 +64,7 @@ namespace azurecp
                 try
                 {
                     ClaimsProviderLogging.Log($"[{AzureCP._ProviderInternalName}] Uninstalling farm-scoped feature for claims provider \"{AzureCP._ProviderInternalName}\": Deleting configuration from the farm", TraceSeverity.High, EventSeverity.Information, ClaimsProviderLogging.TraceCategory.Configuration);
-                    AzureCPConfig.DeleteConfiguration(ClaimsProviderConstants.AZURECPCONFIG_NAME);
+                    AzureCPConfig.DeleteConfiguration(ClaimsProviderConstants.CONFIG_NAME);
                     ClaimsProviderLogging.Unregister();
                 }
                 catch (Exception ex)

--- a/AzureCP/Properties/AssemblyInfo.cs
+++ b/AzureCP/Properties/AssemblyInfo.cs
@@ -34,4 +34,4 @@ using System.Security;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("13.Beta")]
+[assembly: AssemblyFileVersion("13")]

--- a/AzureCP/Properties/AssemblyInfo.cs
+++ b/AzureCP/Properties/AssemblyInfo.cs
@@ -34,4 +34,4 @@ using System.Security;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("12")]
+[assembly: AssemblyFileVersion("13.Beta")]

--- a/AzureCP/TEMPLATE/ADMIN/AzureCP/AzureCPGlobalSettings.ascx
+++ b/AzureCP/TEMPLATE/ADMIN/AzureCP/AzureCPGlobalSettings.ascx
@@ -50,19 +50,25 @@
         line-height: 1.8;
         width: 250px;
     }
-
-    #divNewLdapConnection fieldset {
-        border: 1;
-        margin: 0;
-        padding: 0;
+	
+	#divUserIdentifiers label {
+        display: inline-block;
+        line-height: 1.8;
+        width: 250px;
     }
 
-        #divNewLdapConnection fieldset ul {
+    fieldset {
+        border: 1;
+        margin: 0;
+		padding: 0;
+    }
+
+        fieldset ul {
             margin: 0;
             padding: 0;
         }
 
-        #divNewLdapConnection fieldset li {
+        fieldset li {
             list-style: none;
             padding: 5px;
             margin: 0;
@@ -148,7 +154,7 @@
 				<legend>Details about new Azure AD tenant</legend>
 				<ul>
 					<li>
-						<label for="<%= TxtTenantName.ClientID %>">Tenant <a href="http://msdn.microsoft.com/en-us/library/system.directoryservices.directoryentry.path(v=vs.110).aspx" target="_blank">name</a>: <em>*</em></label>
+						<label for="<%= TxtTenantName.ClientID %>">Tenant name: <em>*</em></label>
 						<wssawc:InputFormTextBox title="Azure tenant name" class="ms-input" ID="TxtTenantName" Columns="50" Runat="server" MaxLength="255" Text="TENANTNAME.onMicrosoft.com" />
 					</li>
 					<li>
@@ -179,28 +185,25 @@
 			</td></tr>
 		 </template_inputformcontrols>
     </wssuc:inputformsection>
-    <wssuc:inputformsection runat="server" title="Display of entities created with identity claim type" description="Customize the display text of entities created with identity claim type (which is defined in the TrustedLoginProvider).<br/>It does not change the actual value of the entity.">
+	<wssuc:inputformsection runat="server" title="User identifier property" description="Set the property defined in Azure Active Directory to identify users.<br/><br/>AzureCP automatically maps those properties with the identity claim type set in the SharePoint TrustedLoginProvider">
         <template_inputformcontrols>
-                <div id="divUserIdentifiers">
-				<fieldset>
-					<legend>User identifier property</legend>
-					<ul>
-						<li>
-							<label>User identifier for 'Member' users:</label>
-							<asp:DropDownList runat="server" ID="DDLDirectoryPropertyMemberUsers" class="ms-input">
-							</asp:DropDownList>
-						</li>
-						<li>
-							<label>User identifier for 'Guest' users:</label>
-							<asp:DropDownList runat="server" ID="DDLDirectoryPropertyGuestUsers" class="ms-input">
-							</asp:DropDownList>
-						</li>
-				</fieldset>
-				</div>
+			<div id="divUserIdentifiers">
+			<label>User identifier for 'Member' users:</label>
+			<asp:DropDownList runat="server" ID="DDLDirectoryPropertyMemberUsers" class="ms-input">
+			</asp:DropDownList>
+			<br/>
+			<label>User identifier for 'Guest' users:</label>
+			<asp:DropDownList runat="server" ID="DDLDirectoryPropertyGuestUsers" class="ms-input">
+			</asp:DropDownList>
+			</div> 
+		</template_inputformcontrols>
+    </wssuc:inputformsection>
+    <wssuc:inputformsection runat="server" title="Display of user identifier results" description="Configure how entities created with identity claim type are shown in the people picker.<br/>It does not change the actual value of the entity, that is the user identifier.">
+        <template_inputformcontrols>
 				<wssawc:InputFormRadioButton id="RbIdentityDefault"
 					LabelText="Display the UserPrincipalName"
 					Checked="true"
-                    GroupName="RbIdentityDisplay"
+					GroupName="RbIdentityDisplay"
 					CausesValidation="false"
 					runat="server" >
                 </wssawc:InputFormRadioButton>

--- a/AzureCP/TEMPLATE/ADMIN/AzureCP/AzureCPGlobalSettings.ascx
+++ b/AzureCP/TEMPLATE/ADMIN/AzureCP/AzureCPGlobalSettings.ascx
@@ -54,7 +54,7 @@
     #divNewLdapConnection fieldset {
         border: 1;
         margin: 0;
-		padding: 0;
+        padding: 0;
     }
 
         #divNewLdapConnection fieldset ul {
@@ -181,10 +181,26 @@
     </wssuc:inputformsection>
     <wssuc:inputformsection runat="server" title="Display of entities created with identity claim type" description="Customize the display text of entities created with identity claim type (which is defined in the TrustedLoginProvider).<br/>It does not change the actual value of the entity.">
         <template_inputformcontrols>
+                <div id="divUserIdentifiers">
+				<fieldset>
+					<legend>User identifier property</legend>
+					<ul>
+						<li>
+							<label>User identifier for 'Member' users:</label>
+							<asp:DropDownList runat="server" ID="DDLDirectoryPropertyMemberUsers" class="ms-input">
+							</asp:DropDownList>
+						</li>
+						<li>
+							<label>User identifier for 'Guest' users:</label>
+							<asp:DropDownList runat="server" ID="DDLDirectoryPropertyGuestUsers" class="ms-input">
+							</asp:DropDownList>
+						</li>
+				</fieldset>
+				</div>
 				<wssawc:InputFormRadioButton id="RbIdentityDefault"
 					LabelText="Display the UserPrincipalName"
 					Checked="true"
-					GroupName="RbIdentityDisplay"
+                    GroupName="RbIdentityDisplay"
 					CausesValidation="false"
 					runat="server" >
                 </wssawc:InputFormRadioButton>

--- a/AzureCP/TEMPLATE/ADMIN/AzureCP/AzureCPGlobalSettings.ascx
+++ b/AzureCP/TEMPLATE/ADMIN/AzureCP/AzureCPGlobalSettings.ascx
@@ -185,7 +185,7 @@
 			</td></tr>
 		 </template_inputformcontrols>
     </wssuc:inputformsection>
-	<wssuc:inputformsection runat="server" title="User identifier property" description="Set the property defined in Azure Active Directory to identify users.<br/><br/>AzureCP automatically maps those properties with the identity claim type set in the SharePoint TrustedLoginProvider">
+	<wssuc:inputformsection runat="server" title="User identifier property" description="Set the properties that identify users in Azure Active Directory.<br/><br/>AzureCP automatically maps those properties with the identity claim type set in the SharePoint TrustedLoginProvider">
         <template_inputformcontrols>
 			<div id="divUserIdentifiers">
 			<label>User identifier for 'Member' users:</label>

--- a/AzureCP/TEMPLATE/ADMIN/AzureCP/AzureCPGlobalSettings.ascx
+++ b/AzureCP/TEMPLATE/ADMIN/AzureCP/AzureCPGlobalSettings.ascx
@@ -50,8 +50,8 @@
         line-height: 1.8;
         width: 250px;
     }
-	
-	#divUserIdentifiers label {
+
+    #divUserIdentifiers label {
         display: inline-block;
         line-height: 1.8;
         width: 250px;
@@ -60,7 +60,7 @@
     fieldset {
         border: 1;
         margin: 0;
-		padding: 0;
+        padding: 0;
     }
 
         fieldset ul {
@@ -185,7 +185,7 @@
 			</td></tr>
 		 </template_inputformcontrols>
     </wssuc:inputformsection>
-	<wssuc:inputformsection runat="server" title="User identifier property" description="Set the properties that identify users in Azure Active Directory.<br/><br/>AzureCP automatically maps those properties with the identity claim type set in the SharePoint TrustedLoginProvider">
+    <wssuc:inputformsection runat="server" title="User identifier property" description="Set the properties that identify users in Azure Active Directory.<br/><br/>AzureCP automatically maps those properties with the identity claim type set in the SharePoint TrustedLoginProvider">
         <template_inputformcontrols>
 			<div id="divUserIdentifiers">
 			<label>User identifier for 'Member' users:</label>
@@ -201,20 +201,19 @@
     <wssuc:inputformsection runat="server" title="Display of user identifier results" description="Configure how entities created with identity claim type are shown in the people picker.<br/>It does not change the actual value of the entity, that is the user identifier.">
         <template_inputformcontrols>
 				<wssawc:InputFormRadioButton id="RbIdentityDefault"
-					LabelText="Display the UserPrincipalName"
+					LabelText="Show the user identifier value"
 					Checked="true"
 					GroupName="RbIdentityDisplay"
 					CausesValidation="false"
 					runat="server" >
                 </wssawc:InputFormRadioButton>
 				<wssawc:InputFormRadioButton id="RbIdentityCustomGraphProperty"
-					LabelText="Display another property"
+					LabelText="Show the value of another property, e.g the display name:"
 					GroupName="RbIdentityDisplay"
 					CausesValidation="false"
 					runat="server" >
                 <wssuc:InputFormControl LabelText="InputFormControlLabelText">
 					<Template_control>
-						<wssawc:EncodedLiteral runat="server" text="You can choose to display a specific property (e.g the display name):<br/>" EncodeMethod='HtmlEncodeAllowSimpleTextFormatting'/>
                         <asp:DropDownList runat="server" ID="DDLGraphPropertyToDisplay" onclick="window.Azurecp.AzurecpSettingsPage.CheckRbIdentityCustomGraphProperty()" class="ms-input" />
 					</Template_control>
 				</wssuc:InputFormControl>

--- a/AzureCP/TEMPLATE/ADMIN/AzureCP/AzureCPGlobalSettings.ascx.cs
+++ b/AzureCP/TEMPLATE/ADMIN/AzureCP/AzureCPGlobalSettings.ascx.cs
@@ -128,6 +128,15 @@ namespace azurecp.ControlTemplates
             PersistedObject.AlwaysResolveUserInput = this.ChkAlwaysResolveUserInput.Checked;
             PersistedObject.FilterExactMatchOnly = this.ChkFilterExactMatchOnly.Checked;
             PersistedObject.EnableAugmentation = this.ChkAugmentAADRoles.Checked;
+
+            AzureADObjectProperty newUserIdentifier = (AzureADObjectProperty)Convert.ToInt32(this.DDLDirectoryPropertyMemberUsers.SelectedValue);
+            if (IdentityClaim.DirectoryObjectProperty != newUserIdentifier)
+                PersistedObject.ClaimTypes.UpdateUserIdentifier(newUserIdentifier);
+
+            AzureADObjectProperty newIdentifierForGuestUsers = (AzureADObjectProperty)Convert.ToInt32(this.DDLDirectoryPropertyGuestUsers.SelectedValue);
+            if (IdentityClaim.DirectoryObjectPropertyForGuestUsers != newIdentifierForGuestUsers)
+                PersistedObject.ClaimTypes.UpdateIdentifierForGuestUsers(newIdentifierForGuestUsers);
+
             if (commitChanges) CommitChanges();
             return true;
         }

--- a/AzureCP/TEMPLATE/ADMIN/AzureCP/AzureCPGlobalSettings.ascx.cs
+++ b/AzureCP/TEMPLATE/ADMIN/AzureCP/AzureCPGlobalSettings.ascx.cs
@@ -68,6 +68,8 @@ namespace azurecp.ControlTemplates
                 this.RbIdentityCustomGraphProperty.Checked = true;
                 this.DDLGraphPropertyToDisplay.Items.FindByValue(((int)IdentityClaim.DirectoryObjectPropertyToShowAsDisplayText).ToString()).Selected = true;
             }
+            this.DDLDirectoryPropertyMemberUsers.Items.FindByValue(((int)IdentityClaim.DirectoryObjectProperty).ToString()).Selected = true;
+            this.DDLDirectoryPropertyGuestUsers.Items.FindByValue(((int)IdentityClaim.DirectoryObjectPropertyForGuestUsers).ToString()).Selected = true;
             this.ChkAlwaysResolveUserInput.Checked = PersistedObject.AlwaysResolveUserInput;
             this.ChkFilterExactMatchOnly.Checked = PersistedObject.FilterExactMatchOnly;
             this.ChkAugmentAADRoles.Checked = PersistedObject.EnableAugmentation;
@@ -85,7 +87,10 @@ namespace azurecp.ControlTemplates
                 if (pi == null) continue;
                 if (pi.PropertyType != typeof(System.String)) continue;
 
+                //System.Web.UI.WebControls.ListItem listItem = new System.Web.UI.WebControls.ListItem(prop.ToString(), ((int)prop).ToString());
                 this.DDLGraphPropertyToDisplay.Items.Add(new System.Web.UI.WebControls.ListItem(prop.ToString(), ((int)prop).ToString()));
+                this.DDLDirectoryPropertyMemberUsers.Items.Add(new System.Web.UI.WebControls.ListItem(prop.ToString(), ((int)prop).ToString()));
+                this.DDLDirectoryPropertyGuestUsers.Items.Add(new System.Web.UI.WebControls.ListItem(prop.ToString(), ((int)prop).ToString()));
             }
         }
 

--- a/AzureCP/TEMPLATE/ADMIN/AzureCP/AzureCPGlobalSettings.ascx.cs
+++ b/AzureCP/TEMPLATE/ADMIN/AzureCP/AzureCPGlobalSettings.ascx.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Graph;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Microsoft.SharePoint.Administration;
-using Microsoft.SharePoint.Utilities;
 using Microsoft.SharePoint.WebControls;
 using System;
 using System.Collections.Generic;
@@ -32,7 +31,7 @@ namespace azurecp.ControlTemplates
         {
             if (ValidatePrerequisite() != ConfigStatus.AllGood)
             {
-                this.LabelErrorMessage.Text = SPEncode.HtmlEncode(base.MostImportantError);
+                this.LabelErrorMessage.Text = base.MostImportantError;
                 this.BtnOK.Enabled = this.BtnOKTop.Enabled = false;
                 return;
             }
@@ -165,7 +164,7 @@ namespace azurecp.ControlTemplates
         {
             if (ValidatePrerequisite() != ConfigStatus.AllGood) return;
             if (UpdateConfiguration(true)) Response.Redirect("/Security.aspx", false);
-            else LabelErrorMessage.Text = SPEncode.HtmlEncode(base.MostImportantError);
+            else LabelErrorMessage.Text = base.MostImportantError;
         }
 
         protected void BtnResetAzureCPConfig_Click(Object sender, EventArgs e)

--- a/AzureCP/TEMPLATE/ADMIN/AzureCP/AzureCPGlobalSettings.ascx.cs
+++ b/AzureCP/TEMPLATE/ADMIN/AzureCP/AzureCPGlobalSettings.ascx.cs
@@ -59,17 +59,17 @@ namespace azurecp.ControlTemplates
 
         private void PopulateFields()
         {
-            if (IdentityClaim.DirectoryObjectPropertyToShowAsDisplayText == AzureADObjectProperty.NotSet)
+            if (IdentityCTConfig.DirectoryObjectPropertyToShowAsDisplayText == AzureADObjectProperty.NotSet)
             {
                 this.RbIdentityDefault.Checked = true;
             }
             else
             {
                 this.RbIdentityCustomGraphProperty.Checked = true;
-                this.DDLGraphPropertyToDisplay.Items.FindByValue(((int)IdentityClaim.DirectoryObjectPropertyToShowAsDisplayText).ToString()).Selected = true;
+                this.DDLGraphPropertyToDisplay.Items.FindByValue(((int)IdentityCTConfig.DirectoryObjectPropertyToShowAsDisplayText).ToString()).Selected = true;
             }
-            this.DDLDirectoryPropertyMemberUsers.Items.FindByValue(((int)IdentityClaim.DirectoryObjectProperty).ToString()).Selected = true;
-            this.DDLDirectoryPropertyGuestUsers.Items.FindByValue(((int)IdentityClaim.DirectoryObjectPropertyForGuestUsers).ToString()).Selected = true;
+            this.DDLDirectoryPropertyMemberUsers.Items.FindByValue(((int)IdentityCTConfig.DirectoryObjectProperty).ToString()).Selected = true;
+            this.DDLDirectoryPropertyGuestUsers.Items.FindByValue(((int)IdentityCTConfig.DirectoryObjectPropertyForGuestUsers).ToString()).Selected = true;
             this.ChkAlwaysResolveUserInput.Checked = PersistedObject.AlwaysResolveUserInput;
             this.ChkFilterExactMatchOnly.Checked = PersistedObject.FilterExactMatchOnly;
             this.ChkAugmentAADRoles.Checked = PersistedObject.EnableAugmentation;
@@ -115,27 +115,26 @@ namespace azurecp.ControlTemplates
         {
             if (ValidatePrerequisite() != ConfigStatus.AllGood) return false;
 
-            // Handle identity claim type
             if (this.RbIdentityCustomGraphProperty.Checked)
             {
-                IdentityClaim.DirectoryObjectPropertyToShowAsDisplayText = (AzureADObjectProperty)Convert.ToInt32(this.DDLGraphPropertyToDisplay.SelectedValue);
+                IdentityCTConfig.DirectoryObjectPropertyToShowAsDisplayText = (AzureADObjectProperty)Convert.ToInt32(this.DDLGraphPropertyToDisplay.SelectedValue);
             }
             else
             {
-                IdentityClaim.DirectoryObjectPropertyToShowAsDisplayText = AzureADObjectProperty.NotSet;
+                IdentityCTConfig.DirectoryObjectPropertyToShowAsDisplayText = AzureADObjectProperty.NotSet;
             }
+
+            AzureADObjectProperty newUserIdentifier = (AzureADObjectProperty)Convert.ToInt32(this.DDLDirectoryPropertyMemberUsers.SelectedValue);
+            if (newUserIdentifier != AzureADObjectProperty.NotSet)
+                PersistedObject.ClaimTypes.UpdateUserIdentifier(newUserIdentifier);
+
+            AzureADObjectProperty newIdentifierForGuestUsers = (AzureADObjectProperty)Convert.ToInt32(this.DDLDirectoryPropertyGuestUsers.SelectedValue);
+            if (newIdentifierForGuestUsers != AzureADObjectProperty.NotSet)
+                PersistedObject.ClaimTypes.UpdateIdentifierForGuestUsers(newIdentifierForGuestUsers);
 
             PersistedObject.AlwaysResolveUserInput = this.ChkAlwaysResolveUserInput.Checked;
             PersistedObject.FilterExactMatchOnly = this.ChkFilterExactMatchOnly.Checked;
             PersistedObject.EnableAugmentation = this.ChkAugmentAADRoles.Checked;
-
-            AzureADObjectProperty newUserIdentifier = (AzureADObjectProperty)Convert.ToInt32(this.DDLDirectoryPropertyMemberUsers.SelectedValue);
-            if (IdentityClaim.DirectoryObjectProperty != newUserIdentifier)
-                PersistedObject.ClaimTypes.UpdateUserIdentifier(newUserIdentifier);
-
-            AzureADObjectProperty newIdentifierForGuestUsers = (AzureADObjectProperty)Convert.ToInt32(this.DDLDirectoryPropertyGuestUsers.SelectedValue);
-            if (IdentityClaim.DirectoryObjectPropertyForGuestUsers != newIdentifierForGuestUsers)
-                PersistedObject.ClaimTypes.UpdateIdentifierForGuestUsers(newIdentifierForGuestUsers);
 
             if (commitChanges) CommitChanges();
             return true;

--- a/AzureCP/TEMPLATE/ADMIN/AzureCP/AzureCPGlobalSettings.ascx.cs
+++ b/AzureCP/TEMPLATE/ADMIN/AzureCP/AzureCPGlobalSettings.ascx.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Graph;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Microsoft.SharePoint.Administration;
+using Microsoft.SharePoint.Utilities;
 using Microsoft.SharePoint.WebControls;
 using System;
 using System.Collections.Generic;
@@ -31,7 +32,7 @@ namespace azurecp.ControlTemplates
         {
             if (ValidatePrerequisite() != ConfigStatus.AllGood)
             {
-                this.LabelErrorMessage.Text = base.MostImportantError;
+                this.LabelErrorMessage.Text = SPEncode.HtmlEncode(base.MostImportantError);
                 this.BtnOK.Enabled = this.BtnOKTop.Enabled = false;
                 return;
             }
@@ -164,7 +165,7 @@ namespace azurecp.ControlTemplates
         {
             if (ValidatePrerequisite() != ConfigStatus.AllGood) return;
             if (UpdateConfiguration(true)) Response.Redirect("/Security.aspx", false);
-            else LabelErrorMessage.Text = MostImportantError;
+            else LabelErrorMessage.Text = SPEncode.HtmlEncode(base.MostImportantError);
         }
 
         protected void BtnResetAzureCPConfig_Click(Object sender, EventArgs e)

--- a/AzureCP/TEMPLATE/ADMIN/AzureCP/AzureCPGlobalSettings.ascx.designer.cs
+++ b/AzureCP/TEMPLATE/ADMIN/AzureCP/AzureCPGlobalSettings.ascx.designer.cs
@@ -130,6 +130,24 @@ namespace azurecp.ControlTemplates {
         protected global::System.Web.UI.WebControls.Label LabelTestTenantConnectionOK;
         
         /// <summary>
+        /// DDLDirectoryPropertyMemberUsers control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.DropDownList DDLDirectoryPropertyMemberUsers;
+        
+        /// <summary>
+        /// DDLDirectoryPropertyGuestUsers control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.DropDownList DDLDirectoryPropertyGuestUsers;
+        
+        /// <summary>
         /// RbIdentityDefault control.
         /// </summary>
         /// <remarks>

--- a/AzureCP/TEMPLATE/ADMIN/AzureCP/AzureCPSettings.aspx
+++ b/AzureCP/TEMPLATE/ADMIN/AzureCP/AzureCPSettings.aspx
@@ -12,6 +12,6 @@
 </asp:Content>
 <asp:Content ID="Main" ContentPlaceHolderID="PlaceHolderMain" runat="server">
     <table border="0" cellspacing="0" cellpadding="0" width="100%">
-        <AzureCP:GlobalSettings ID="AzureCPGlobalSettings" Runat="server" ClaimsProviderName="AzureCP" PersistedObjectName="<%# ClaimsProviderConstants.AZURECPCONFIG_NAME %>" PersistedObjectID="<%# ClaimsProviderConstants.AZURECPCONFIG_ID %>" />
+        <AzureCP:GlobalSettings ID="AzureCPGlobalSettings" Runat="server" ClaimsProviderName="AzureCP" PersistedObjectName="<%# ClaimsProviderConstants.CONFIG_NAME %>" PersistedObjectID="<%# ClaimsProviderConstants.CONFIG_ID %>" />
     </table>
 </asp:Content>

--- a/AzureCP/TEMPLATE/ADMIN/AzureCP/AzureCPSettings.aspx
+++ b/AzureCP/TEMPLATE/ADMIN/AzureCP/AzureCPSettings.aspx
@@ -12,6 +12,6 @@
 </asp:Content>
 <asp:Content ID="Main" ContentPlaceHolderID="PlaceHolderMain" runat="server">
     <table border="0" cellspacing="0" cellpadding="0" width="100%">
-        <AzureCP:GlobalSettings ID="LdapcpGlobalSettings" Runat="server" ClaimsProviderName="AzureCP" PersistedObjectName="<%# ClaimsProviderConstants.AZURECPCONFIG_NAME %>" PersistedObjectID="<%# ClaimsProviderConstants.AZURECPCONFIG_ID %>" />
+        <AzureCP:GlobalSettings ID="AzureCPGlobalSettings" Runat="server" ClaimsProviderName="AzureCP" PersistedObjectName="<%# ClaimsProviderConstants.AZURECPCONFIG_NAME %>" PersistedObjectID="<%# ClaimsProviderConstants.AZURECPCONFIG_ID %>" />
     </table>
 </asp:Content>

--- a/AzureCP/TEMPLATE/ADMIN/AzureCP/AzureCPSettings.aspx
+++ b/AzureCP/TEMPLATE/ADMIN/AzureCP/AzureCPSettings.aspx
@@ -8,7 +8,7 @@
 <asp:Content ID="PageHead" ContentPlaceHolderID="PlaceHolderAdditionalPageHead" runat="server" />
 <asp:Content ID="PageTitle" ContentPlaceHolderID="PlaceHolderPageTitle" runat="server">AzureCP Configuration</asp:Content>
 <asp:Content ID="PageTitleInTitleArea" ContentPlaceHolderID="PlaceHolderPageTitleInTitleArea" runat="server">
-<%= String.Format("AzureCP v{0} - <a href=\"{1}\" target=\"_blank\">Visit AzureCP site</a>", FileVersionInfo.GetVersionInfo(Assembly.GetAssembly(typeof(AzureCP)).Location).FileVersion, ClaimsProviderConstants.PUBLICSITEURL) %>
+<%= String.Format("AzureCP v{0} - <a href=\"{1}\" target=\"_blank\">Visit AzureCP site</a>", ClaimsProviderConstants.ClaimsProviderVersion, ClaimsProviderConstants.PUBLICSITEURL) %>
 </asp:Content>
 <asp:Content ID="Main" ContentPlaceHolderID="PlaceHolderMain" runat="server">
     <table border="0" cellspacing="0" cellpadding="0" width="100%">

--- a/AzureCP/TEMPLATE/ADMIN/AzureCP/ClaimTypesConfig.ascx.cs
+++ b/AzureCP/TEMPLATE/ADMIN/AzureCP/ClaimTypesConfig.ascx.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Graph;
-using Microsoft.SharePoint.Utilities;
 using Microsoft.SharePoint.WebControls;
 using System;
 using System.Collections.Generic;
@@ -45,7 +44,7 @@ namespace azurecp.ControlTemplates
             ConfigStatus status = ValidatePrerequisite();
             if (status != ConfigStatus.AllGood && status != ConfigStatus.NoIdentityClaimType)
             {
-                this.LabelErrorMessage.Text = SPEncode.HtmlEncode(base.MostImportantError);
+                this.LabelErrorMessage.Text = base.MostImportantError;
                 this.HideAllContent = true;
                 this.BtnCreateNewItem.Visible = false;
                 return;

--- a/AzureCP/TEMPLATE/ADMIN/AzureCP/ClaimTypesConfig.ascx.cs
+++ b/AzureCP/TEMPLATE/ADMIN/AzureCP/ClaimTypesConfig.ascx.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Graph;
+using Microsoft.SharePoint.Utilities;
 using Microsoft.SharePoint.WebControls;
 using System;
 using System.Collections.Generic;
@@ -44,7 +45,7 @@ namespace azurecp.ControlTemplates
             ConfigStatus status = ValidatePrerequisite();
             if (status != ConfigStatus.AllGood && status != ConfigStatus.NoIdentityClaimType)
             {
-                this.LabelErrorMessage.Text = base.MostImportantError;
+                this.LabelErrorMessage.Text = SPEncode.HtmlEncode(base.MostImportantError);
                 this.HideAllContent = true;
                 this.BtnCreateNewItem.Visible = false;
                 return;
@@ -371,7 +372,7 @@ namespace azurecp.ControlTemplates
                 return;
             }
 
-            ClaimTypeConfig newCTConfig = existingCTConfig.CopyCurrentObject();
+            ClaimTypeConfig newCTConfig = existingCTConfig.CopyPersistedProperties();
             newCTConfig.ClaimType = newClaimType;
             newCTConfig.EntityType = typeSelected;
             newCTConfig.PrefixToBypassLookup = formData["input_PrefixToBypassLookup_" + itemId];

--- a/AzureCP/TEMPLATE/ADMIN/AzureCP/ClaimTypesConfig.aspx
+++ b/AzureCP/TEMPLATE/ADMIN/AzureCP/ClaimTypesConfig.aspx
@@ -15,6 +15,6 @@
 </asp:Content>
 <asp:Content ID="Main" ContentPlaceHolderID="PlaceHolderMain" runat="server">
     <table border="0" cellspacing="0" cellpadding="0" width="100%">
-        <AzureCP:ClaimTypesConfigUC ID="LdapcpClaimsList" Runat="server" ClaimsProviderName="AzureCP" PersistedObjectName="<%# ClaimsProviderConstants.AZURECPCONFIG_NAME %>" PersistedObjectID="<%# ClaimsProviderConstants.AZURECPCONFIG_ID %>" />
+        <AzureCP:ClaimTypesConfigUC ID="AzureCPClaimsList" Runat="server" ClaimsProviderName="AzureCP" PersistedObjectName="<%# ClaimsProviderConstants.CONFIG_NAME %>" PersistedObjectID="<%# ClaimsProviderConstants.CONFIG_ID %>" />
     </table>
 </asp:Content>

--- a/AzureCP/packages.config
+++ b/AzureCP/packages.config
@@ -3,10 +3,10 @@
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
-  <package id="Microsoft.Graph" version="1.9.0" targetFramework="net45" />
-  <package id="Microsoft.Graph.Core" version="1.9.0" targetFramework="net45" />
-  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.19.4" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net45" />
+  <package id="Microsoft.Graph" version="1.10.0" targetFramework="net45" />
+  <package id="Microsoft.Graph.Core" version="1.10.0" targetFramework="net45" />
+  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.19.8" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="Nito.AsyncEx.StrongNamed" version="4.0.1" targetFramework="net45" />
   <package id="System.Net.Http" version="4.3.3" targetFramework="net45" />
 </packages>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Implemented unit tests
 * Explicitely encode HTML messages shown in admin pages and renderred from server side code to comply with tools scanning code to detect security vulnerabilities
 * Fixed display text of groups that were not using the expected format "(GROUP) groupname"
+* Deactivating farm-scoped feature "AzureCP" removes the claims provider from the farm, but it does not delete its configuration anymore. Configuration is now deleted when feature is uninstalled (typically when retracting the solution)
 
 
 ## AzureCP v12 enhancements & bug-fixes - Published in June 7, 2018

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Added method ClaimTypeConfigCollection.GetByClaimType()
 * Implemented unit tests
 * Explicitely encode HTML messages shown in admin pages and renderred from server side code to comply with tools scanning code to detect security vulnerabilities
+* Fixed display text of groups that were not using the expected format "(GROUP) groupname"
 
 
 ## AzureCP v12 enhancements & bug-fixes - Published in June 7, 2018

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Change log for AzureCP
+
+## AzureCP v13 enhancements & bug-fixes
+
+* Guest users are now fully supported. AzureCP will use the Mail property to search Guest accounts and create their permissions in SharePoint
+* The identity claim type set in the SPTrustedIdentityTokenIssuer is now automatically detected and associated with the UserPrincipalName property
+* Fixed no result returned under high load, caused by a thread safety issue where the same filter was used in all threads regardless of the actual input
+* Improved validation of changes made to ClaimTypes collection
+* Added method ClaimTypeConfigCollection.GetByClaimType()
+* Implemented unit tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## AzureCP v13 enhancements & bug-fixes
 
 * Guest users are now fully supported. AzureCP will use the Mail property to search Guest accounts and create their permissions in SharePoint
-* The identity claim type set in the SPTrustedIdentityTokenIssuer is now automatically detected and associated with the UserPrincipalName property
+* The identity claim type set in the SPTrustedIdentityTokenIssuer is now automatically detected and associated with the property UserPrincipalName
 * Fixed no result returned under high load, caused by a thread safety issue where the same filter was used in all threads regardless of the actual input
 * Improved validation of changes made to ClaimTypes collection
 * Added method ClaimTypeConfigCollection.GetByClaimType()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@
 * Improved validation of changes made to ClaimTypes collection
 * Added method ClaimTypeConfigCollection.GetByClaimType()
 * Implemented unit tests
+* Explicitely encode HTML messages shown in admin pages and renderred from server side code to comply with tools scanning code to detect security vulnerabilities

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## AzureCP v13 enhancements & bug-fixes - Published in August 30, 2018
 
-* Guest users are now fully supported. AzureCP will use the Mail property to search Guest accounts and create their permissions in SharePoint
+* Guest users are now fully supported. By default, AzureCP will use the Mail property to search Guest accounts and create their permissions in SharePoint
 * The identity claim type set in the SPTrustedIdentityTokenIssuer is now automatically detected and associated with the property UserPrincipalName
 * Fixed no result returned under high load, caused by a thread safety issue where the same filter was used in all threads regardless of the actual input
 * Improved validation of changes made to ClaimTypes collection
 * Added method ClaimTypeConfigCollection.GetByClaimType()
 * Implemented unit tests
-* Explicitely encode HTML messages shown in admin pages and renderred from server side code to comply with tools scanning code to detect security vulnerabilities
+* Explicitly encode HTML messages shown in admin pages and rendered from server side code to comply with tools scanning code to detect security vulnerabilities
 * Fixed display text of groups that were not using the expected format "(GROUP) groupname"
 * Deactivating farm-scoped feature "AzureCP" removes the claims provider from the farm, but it does not delete its configuration anymore. Configuration is now deleted when feature is uninstalled (typically when retracting the solution)
 * Added user identifier properties in global configuration page

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Explicitely encode HTML messages shown in admin pages and renderred from server side code to comply with tools scanning code to detect security vulnerabilities
 * Fixed display text of groups that were not using the expected format "(GROUP) groupname"
 * Deactivating farm-scoped feature "AzureCP" removes the claims provider from the farm, but it does not delete its configuration anymore. Configuration is now deleted when feature is uninstalled (typically when retracting the solution)
-
+* Added user identifier properties in global configuration page
 
 ## AzureCP v12 enhancements & bug-fixes - Published in June 7, 2018
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,19 @@
 * Added method ClaimTypeConfigCollection.GetByClaimType()
 * Implemented unit tests
 * Explicitely encode HTML messages shown in admin pages and renderred from server side code to comply with tools scanning code to detect security vulnerabilities
+
+
+## AzureCP v12 enhancements & bug-fixes - Published in June 7, 2018
+
+* Improved: AzureCP now uses the unified [Microsoft Graph API](https://developer.microsoft.com/en-us/graph/) instead of the old [Azure AD Graph API](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-graph-api).
+* New: AzureCP can be entirely configured with PowerShell, including claim types configuration
+* Updated: AzureCP administration pages are now created as User Controls and are reusable by developers.
+* Improved: AzureCP claims mapping page is easier to understand
+* Updated: Logging is more relevant and generates less messages.
+* New: Timeout of connection is 4 secs and can be customized
+* Improved: When multiple tenants are set, they are queried in parallel
+* Updated: Tenant ID is no longer needed to register a tenant
+* Improved: Nested groups are now supported, if group permissions are created using the ID of groups (new default setting).
+* **Beaking change**: By default, AzureCP now creates group permissions using the Id of the group instead of its name (group IDs are unique, not names). There are 2 ways to deal with this: Modify group claim type configuration to reuse the name, or migrate existing groups permissions to set their values with their group ID
+* **Beaking change**: Due to the amount of changes in this area, the claim types configuration will be reset if you update from an earlier version.
+* Many bug fixes and optimizations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log for AzureCP
 
-## AzureCP v13 enhancements & bug-fixes
+## AzureCP v13 enhancements & bug-fixes - Published in August 30, 2018
 
 * Guest users are now fully supported. AzureCP will use the Mail property to search Guest accounts and create their permissions in SharePoint
 * The identity claim type set in the SPTrustedIdentityTokenIssuer is now automatically detected and associated with the property UserPrincipalName


### PR DESCRIPTION
## AzureCP v13 enhancements & bug-fixes

* Guest users are now fully supported. By default, AzureCP will use the Mail property to search Guest accounts and create their permissions in SharePoint
* The identity claim type set in the SPTrustedIdentityTokenIssuer is now automatically detected and associated with the property UserPrincipalName
* Fixed no result returned under high load, caused by a thread safety issue where the same filter was used in all threads regardless of the actual input
* Improved validation of changes made to ClaimTypes collection
* Added method ClaimTypeConfigCollection.GetByClaimType()
* Implemented unit tests
* Explicitly encode HTML messages shown in admin pages and rendered from server side code to comply with tools scanning code to detect security vulnerabilities
* Fixed display text of groups that were not using the expected format "(GROUP) groupname"
* Deactivating farm-scoped feature "AzureCP" removes the claims provider from the farm, but it does not delete its configuration anymore. Configuration is now deleted when feature is uninstalled (typically when retracting the solution)
* Added user identifier properties in global configuration page