### PR TITLE
fix httpcontext for anonymous user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Update the links in the global configuration page - https://github.com/Yvand/EntraCP/pull/324
 * Update the description for the proxy in the global configuration page - https://github.com/Yvand/EntraCP/pull/324
 * Ensure the proxy has a value in a valid format before committing the new configuration - https://github.com/Yvand/EntraCP/pull/324
+* Fix again the exception thrown if the claims provider is used in the context of an anonymous user - https://github.com/Yvand/EntraCP/issues/240
 
 ## EntraCP v29.0.20250721.38 - enhancements & bug-fixes - Published in July 21, 2025
 

--- a/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/ClaimsProviderConstants.cs
+++ b/Yvand.EntraCP/Yvand.EntraClaimsProvider/Configuration/ClaimsProviderConstants.cs
@@ -283,7 +283,7 @@ namespace Yvand.EntraClaimsProvider.Configuration
             if (httpctx != null)
             {
                 WIF4_5.ClaimsPrincipal cp = httpctx.User as WIF4_5.ClaimsPrincipal;
-                if (cp != null && cp.Identity != null)
+                if (cp != null && cp.Identity != null && !String.IsNullOrWhiteSpace(cp.Identity.Name))
                 {
                     if (SPClaimProviderManager.IsEncodedClaim(cp.Identity.Name))
                     {


### PR DESCRIPTION
## CHANGELOG

* Fix again the exception thrown if the claims provider is used in the context of an anonymous user - https://github.com/Yvand/EntraCP/issues/240